### PR TITLE
feat: canvas extension — display HTML in browser with SSE live reload

### DIFF
--- a/.github/extensions/canvas/README.md
+++ b/.github/extensions/canvas/README.md
@@ -1,0 +1,77 @@
+# Canvas Extension
+
+A Copilot CLI extension that lets agents display rich HTML content in the browser. Write a dashboard, render a report, or build an interactive form — the agent generates HTML and it appears in Edge with live reload.
+
+## Quick Example
+
+> "Show me a visual summary of my open PRs"
+
+The agent generates an HTML dashboard and opens it in your browser:
+
+```
+canvas_show:
+  name: pr-dashboard
+  html: "<h1>Open PRs</h1><div class='grid'>..."
+```
+
+Update it without opening a new tab:
+
+```
+canvas_update:
+  name: pr-dashboard
+  html: "<h1>Open PRs (refreshed)</h1>..."
+```
+
+The browser auto-reloads — no manual refresh needed.
+
+## How It Works
+
+1. Agent calls `canvas_show` with HTML content
+2. Extension writes the HTML and starts a local HTTP server
+3. A bridge script is auto-injected for SSE live reload
+4. Edge opens to `http://127.0.0.1:{port}/canvas-name.html`
+5. Agent calls `canvas_update` → server pushes SSE → browser reloads
+
+No websockets. SSE for push, HTTP POST for back-channel.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `canvas_show` | Create a canvas and open it in the browser |
+| `canvas_update` | Update an existing canvas (auto-reloads via SSE) |
+| `canvas_close` | Close a canvas; stops server if none remain |
+| `canvas_list` | List all open canvases with URLs |
+
+## Back-Channel (Browser → Agent)
+
+Canvas pages can send actions back to the agent using the injected bridge:
+
+```js
+// Inside your canvas HTML
+canvas.sendAction("button-clicked", { id: "approve", value: true });
+```
+
+This POSTs to the extension's local server, which routes it into the agent session.
+
+## File Structure
+
+```
+.github/extensions/canvas/
+├── extension.mjs           # Entry point
+├── lib/
+│   └── server.mjs          # HTTP server + SSE + action endpoint
+├── tools/
+│   └── canvas-tools.mjs    # canvas_show, canvas_update, canvas_close, canvas_list
+├── data/
+│   └── content/            # Served HTML files (gitignored)
+└── package.json
+```
+
+## Notes
+
+- HTML fragments are auto-wrapped in a full page with viewport meta tag
+- All served HTML gets the bridge script injected before `</body>`
+- Server binds to `127.0.0.1` only — not exposed to the network
+- No dependencies — uses Node.js built-in `http` module
+- Cache headers set to `no-store` so the browser always gets fresh content

--- a/.github/extensions/canvas/data/.gitkeep
+++ b/.github/extensions/canvas/data/.gitkeep
@@ -1,0 +1,2 @@
+// This directory holds canvas content at runtime.
+// Ignored by git — see .gitignore.

--- a/.github/extensions/canvas/extension.mjs
+++ b/.github/extensions/canvas/extension.mjs
@@ -1,0 +1,43 @@
+// Canvas Extension — Entry Point
+// Registers canvas tools with the Copilot CLI session.
+// Provides a local HTTP server for displaying HTML canvases in the browser.
+
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { approveAll } from "@github/copilot-sdk";
+import { joinSession } from "@github/copilot-sdk/extension";
+
+import { createCanvasServer } from "./lib/server.mjs";
+import { createCanvasTools } from "./tools/canvas-tools.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const extDir = resolve(__dirname);
+const contentDir = join(extDir, "data", "content");
+
+// Action queue — user actions from the browser are stored here
+// and can be consumed by the agent via session events
+const actionQueue = [];
+
+function onAction(action) {
+  actionQueue.push(action);
+  // Log to session if available
+  if (currentSession) {
+    currentSession.log(`Canvas action: ${action.action}`, { ephemeral: true });
+  }
+}
+
+const server = createCanvasServer(contentDir, onAction);
+
+let currentSession = null;
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+  hooks: {
+    onSessionStart: async () => {
+      await session.log("Canvas extension loaded");
+    },
+  },
+  tools: createCanvasTools(contentDir, server, onAction),
+});
+
+currentSession = session;

--- a/.github/extensions/canvas/lib/server.mjs
+++ b/.github/extensions/canvas/lib/server.mjs
@@ -1,0 +1,186 @@
+// Canvas server — local HTTP server with SSE live reload and action back-channel.
+
+import { createServer } from "node:http";
+import { readFileSync, existsSync } from "node:fs";
+import { join, extname } from "node:path";
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+};
+
+/** Bridge script injected into HTML responses. */
+const BRIDGE_SCRIPT = `
+<script>
+(function() {
+  // SSE live reload
+  const es = new EventSource('//__canvas_events');
+  es.onmessage = function() { location.reload(); };
+  es.onerror = function() { setTimeout(function() { location.reload(); }, 2000); };
+
+  // Back-channel: canvas pages can send actions to the agent
+  window.canvas = {
+    sendAction: function(name, data) {
+      return fetch('//__canvas_action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: name, data: data || {}, timestamp: Date.now() })
+      });
+    }
+  };
+})();
+</script>`;
+
+/**
+ * Create and manage a canvas HTTP server.
+ * @param {string} contentDir - Directory to serve files from
+ * @param {function} onAction - Callback when a user action is received
+ * @returns {object} Server controller
+ */
+export function createCanvasServer(contentDir, onAction) {
+  let server = null;
+  let port = null;
+  let sseClients = [];
+
+  function handleRequest(req, res) {
+    // SSE endpoint
+    if (req.url === "//__canvas_events") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.write("data: connected\n\n");
+      sseClients.push(res);
+      req.on("close", () => {
+        sseClients = sseClients.filter((c) => c !== res);
+      });
+      return;
+    }
+
+    // Action back-channel
+    if (req.url === "//__canvas_action" && req.method === "POST") {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try {
+          const action = JSON.parse(body);
+          if (onAction) onAction(action);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end('{"ok":true}');
+        } catch {
+          res.writeHead(400);
+          res.end('{"error":"invalid json"}');
+        }
+      });
+      return;
+    }
+
+    // Static file serving
+    let filePath = req.url === "/" ? "/index.html" : req.url;
+    filePath = filePath.split("?")[0]; // strip query params
+    const fullPath = join(contentDir, filePath);
+
+    // Path traversal protection
+    if (!fullPath.startsWith(contentDir)) {
+      res.writeHead(403);
+      res.end("Forbidden");
+      return;
+    }
+
+    if (!existsSync(fullPath)) {
+      res.writeHead(404);
+      res.end("Not found");
+      return;
+    }
+
+    try {
+      let content = readFileSync(fullPath);
+      const ext = extname(fullPath).toLowerCase();
+      const mime = MIME_TYPES[ext] || "application/octet-stream";
+
+      // Inject bridge script into HTML responses
+      if (ext === ".html") {
+        let html = content.toString("utf-8");
+        if (html.includes("</body>")) {
+          html = html.replace("</body>", `${BRIDGE_SCRIPT}\n</body>`);
+        } else if (html.includes("</html>")) {
+          html = html.replace("</html>", `${BRIDGE_SCRIPT}\n</html>`);
+        } else {
+          html += BRIDGE_SCRIPT;
+        }
+        content = html;
+      }
+
+      res.writeHead(200, {
+        "Content-Type": mime,
+        "Cache-Control": "no-store",
+      });
+      res.end(content);
+    } catch {
+      res.writeHead(500);
+      res.end("Server error");
+    }
+  }
+
+  return {
+    /** Start the server on a random available port. */
+    start() {
+      return new Promise((resolve, reject) => {
+        if (server) {
+          resolve(port);
+          return;
+        }
+        server = createServer(handleRequest);
+        server.listen(0, "127.0.0.1", () => {
+          port = server.address().port;
+          resolve(port);
+        });
+        server.on("error", reject);
+      });
+    },
+
+    /** Push an SSE reload event to all connected clients. */
+    reload() {
+      for (const client of sseClients) {
+        try {
+          client.write("data: reload\n\n");
+        } catch { /* client disconnected */ }
+      }
+    },
+
+    /** Stop the server. */
+    stop() {
+      return new Promise((resolve) => {
+        if (!server) {
+          resolve();
+          return;
+        }
+        // Close all SSE connections
+        for (const client of sseClients) {
+          try { client.end(); } catch { /* ok */ }
+        }
+        sseClients = [];
+        server.close(() => {
+          server = null;
+          port = null;
+          resolve();
+        });
+      });
+    },
+
+    /** Get the current port (null if not running). */
+    getPort() { return port; },
+
+    /** Check if server is running. */
+    isRunning() { return server !== null; },
+  };
+}

--- a/.github/extensions/canvas/package.json
+++ b/.github/extensions/canvas/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "copilot-canvas-extension",
+  "private": true,
+  "type": "module"
+}

--- a/.github/extensions/canvas/tools/canvas-tools.mjs
+++ b/.github/extensions/canvas/tools/canvas-tools.mjs
@@ -1,0 +1,214 @@
+// Canvas tools — canvas_show, canvas_update, canvas_close
+
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { exec } from "node:child_process";
+
+const isWindows = process.platform === "win32";
+
+function openBrowser(url) {
+  const cmd = isWindows
+    ? `start msedge "${url}"`
+    : process.platform === "darwin"
+      ? `open -a "Microsoft Edge" "${url}"`
+      : `xdg-open "${url}"`;
+  exec(cmd, { shell: true }, () => {});
+}
+
+function writeContent(contentDir, filename, html) {
+  if (!existsSync(contentDir)) {
+    mkdirSync(contentDir, { recursive: true });
+  }
+  writeFileSync(join(contentDir, filename), html, "utf-8");
+}
+
+export function createCanvasTools(contentDir, server, onAction) {
+  // Track open canvases: name → { filename, url }
+  const openCanvases = new Map();
+
+  return [
+    {
+      name: "canvas_show",
+      description:
+        "Display HTML content in the user's browser. Creates a local canvas page and opens it in Edge. " +
+        "The HTML can be a full page or a fragment — a bridge script is auto-injected for live reload. " +
+        "Use this for dashboards, reports, visualizations, forms, or any rich visual output.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name (used as identifier). Kebab-case, e.g. 'daily-report', 'pr-dashboard'",
+          },
+          html: {
+            type: "string",
+            description: "Full HTML content to display. Can be a complete page or fragment.",
+          },
+          title: {
+            type: "string",
+            description: "Optional page title. Used if html doesn't include a <title> tag.",
+          },
+          open_browser: {
+            type: "boolean",
+            description: "Whether to open the browser. Defaults to true. Set false to update content without opening a new tab.",
+          },
+        },
+        required: ["name", "html"],
+      },
+      handler: async (args) => {
+        const filename = `${args.name}.html`;
+        let html = args.html;
+
+        // Wrap fragment in a full page if needed
+        if (!html.toLowerCase().includes("<!doctype") && !html.toLowerCase().includes("<html")) {
+          const title = args.title || args.name;
+          html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+</head>
+<body>
+${html}
+</body>
+</html>`;
+        } else if (args.title && !html.toLowerCase().includes("<title>")) {
+          html = html.replace("</head>", `  <title>${args.title}</title>\n</head>`);
+        }
+
+        writeContent(contentDir, filename, html);
+
+        // Start server if not running
+        let port = server.getPort();
+        if (!port) {
+          port = await server.start();
+        }
+
+        const url = `http://127.0.0.1:${port}/${filename}`;
+        openCanvases.set(args.name, { filename, url });
+
+        const shouldOpen = args.open_browser !== false;
+        if (shouldOpen) {
+          openBrowser(url);
+        }
+
+        return `Canvas **${args.name}** is live at ${url}${shouldOpen ? " (opened in Edge)" : ""}`;
+      },
+    },
+
+    {
+      name: "canvas_update",
+      description:
+        "Update the content of an existing canvas. The browser auto-reloads via SSE — no need to reopen. " +
+        "Use this to refresh dashboards, update reports, or push new content to an already-open canvas.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name to update (must have been created with canvas_show)",
+          },
+          html: {
+            type: "string",
+            description: "New HTML content to display",
+          },
+          title: {
+            type: "string",
+            description: "Optional updated page title",
+          },
+        },
+        required: ["name", "html"],
+      },
+      handler: async (args) => {
+        const existing = openCanvases.get(args.name);
+        if (!existing) {
+          return `Error: canvas '${args.name}' not found. Use canvas_show to create it first.`;
+        }
+
+        let html = args.html;
+        if (!html.toLowerCase().includes("<!doctype") && !html.toLowerCase().includes("<html")) {
+          const title = args.title || args.name;
+          html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+</head>
+<body>
+${html}
+</body>
+</html>`;
+        }
+
+        writeContent(contentDir, existing.filename, html);
+        server.reload();
+
+        return `Canvas **${args.name}** updated. Browser will auto-reload.`;
+      },
+    },
+
+    {
+      name: "canvas_close",
+      description:
+        "Close a canvas and optionally stop the canvas server. " +
+        "Removes the canvas content. If no canvases remain, stops the server.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name to close. Use 'all' to close all canvases and stop the server.",
+          },
+        },
+        required: ["name"],
+      },
+      handler: async (args) => {
+        if (args.name === "all") {
+          const count = openCanvases.size;
+          openCanvases.clear();
+          await server.stop();
+          return `Closed ${count} canvas(es) and stopped the server.`;
+        }
+
+        const existing = openCanvases.get(args.name);
+        if (!existing) {
+          return `Error: canvas '${args.name}' not found.`;
+        }
+
+        openCanvases.delete(args.name);
+
+        // Stop server if no canvases remain
+        if (openCanvases.size === 0) {
+          await server.stop();
+          return `Canvas **${args.name}** closed. Server stopped (no remaining canvases).`;
+        }
+
+        return `Canvas **${args.name}** closed. ${openCanvases.size} canvas(es) still active.`;
+      },
+    },
+
+    {
+      name: "canvas_list",
+      description: "List all open canvases with their URLs.",
+      parameters: { type: "object", properties: {} },
+      handler: async () => {
+        if (openCanvases.size === 0) {
+          return "No canvases are open.";
+        }
+
+        const lines = [];
+        for (const [name, info] of openCanvases) {
+          lines.push(`• **${name}** — ${info.url}`);
+        }
+
+        const status = server.isRunning()
+          ? `Server running on port ${server.getPort()}`
+          : "Server not running";
+
+        return `${lines.join("\n")}\n\n${status}`;
+      },
+    },
+  ];
+}

--- a/.github/registry.json
+++ b/.github/registry.json
@@ -1,11 +1,16 @@
 {
-  "version": "0.3.0",
+  "version": "0.5.0",
   "source": "ianphil/genesis",
   "extensions": {
     "cron": {
       "version": "0.3.0",
       "path": ".github/extensions/cron",
       "description": "Scheduled job execution — cron, interval, and one-shot with prompt and command payloads"
+    },
+    "canvas": {
+      "version": "0.5.0",
+      "path": ".github/extensions/canvas",
+      "description": "Display rich HTML content in the browser with SSE live reload"
     }
   },
   "skills": {

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ Thumbs.db
 .github/extensions/cron/data/engine.lock
 .github/extensions/cron/data/engine.log
 .github/extensions/cron/node_modules/
+
+# Canvas extension runtime data
+.github/extensions/canvas/data/content/
+.github/extensions/canvas/node_modules/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Genesis creates your `SOUL.md` (personality) and agent file (role), seeds workin
 | Extension | Description |
 |-----------|-------------|
 | [cron](.github/extensions/cron/) | Scheduled job execution — cron, interval, and one-shot with command and prompt payloads |
+| [canvas](.github/extensions/canvas/) | Display rich HTML content in the browser with SSE live reload |
 
 ## Upgrading Existing Minds
 


### PR DESCRIPTION
## What

A Copilot CLI extension that lets agents display rich HTML content in Edge with live reload.

## Tools
- **canvas_show** — write HTML + open Edge
- **canvas_update** — push new content, browser auto-reloads via SSE
- **canvas_close** — close canvas, stop server if none remain
- **canvas_list** — list open canvases with URLs

## Architecture
- Local HTTP server on 127.0.0.1 (native node:http, zero deps)
- SSE for agent → browser push
- POST /action for browser → agent back-channel
- Bridge script auto-injected into served HTML

## Also
- Registry updated to v0.5.0 with canvas entry
- README updated with canvas in extensions table