### PR TITLE
feat: add OS toast notifications to heartbeat

### DIFF
--- a/.github/extensions/heartbeat/extension.mjs
+++ b/.github/extensions/heartbeat/extension.mjs
@@ -8,6 +8,7 @@ import { joinSession } from "@github/copilot-sdk/extension";
 import { createMemoryTools } from "./tools/memory-tools.mjs";
 import { getMindRoot } from "./lib/paths.mjs";
 import { ensureHeartbeatJob } from "./lib/ensure-job.mjs";
+import { toast } from "./lib/toast.mjs";
 
 const mindRoot = getMindRoot();
 
@@ -21,5 +22,5 @@ const session = await joinSession({
       }
     },
   },
-  tools: createMemoryTools(mindRoot),
+  tools: createMemoryTools(mindRoot, toast),
 });

--- a/.github/extensions/heartbeat/lib/toast.mjs
+++ b/.github/extensions/heartbeat/lib/toast.mjs
@@ -1,0 +1,38 @@
+// Cross-platform toast notifications.
+
+import { exec } from "node:child_process";
+
+const escaped = (s) => s.replace(/'/g, "''").replace(/`/g, "``");
+
+/**
+ * Fire an OS-level toast notification.
+ * Windows: uses WinRT ToastNotificationManager.
+ * macOS: uses osascript.
+ * Linux: uses notify-send.
+ * Fails silently on unsupported platforms.
+ */
+export function toast(title, message) {
+  switch (process.platform) {
+    case "win32": {
+      const ps = `
+        [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null;
+        $xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02);
+        $text = $xml.GetElementsByTagName('text');
+        $text[0].AppendChild($xml.CreateTextNode('${escaped(title)}')) | Out-Null;
+        $text[1].AppendChild($xml.CreateTextNode('${escaped(message)}')) | Out-Null;
+        $notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Genesis');
+        $notifier.Show([Windows.UI.Notifications.ToastNotification]::new($xml))
+      `.replace(/\n/g, " ");
+      exec(`powershell -NoProfile -Command "${ps}"`, () => {});
+      break;
+    }
+    case "darwin": {
+      exec(`osascript -e 'display notification "${message}" with title "${title}"'`, () => {});
+      break;
+    }
+    default: {
+      exec(`notify-send "${title}" "${message}" 2>/dev/null`, () => {});
+      break;
+    }
+  }
+}

--- a/.github/extensions/heartbeat/tools/memory-tools.mjs
+++ b/.github/extensions/heartbeat/tools/memory-tools.mjs
@@ -8,7 +8,7 @@ import { parseMemory, parseLog } from "../lib/parser.mjs";
 import { getMemoryPath, getLogPath } from "../lib/paths.mjs";
 import { removeLogEntries } from "../lib/parser.mjs";
 
-export function createMemoryTools(mindRoot) {
+export function createMemoryTools(mindRoot, toast) {
   return [
     {
       name: "heartbeat_consolidate",
@@ -185,6 +185,9 @@ export function createMemoryTools(mindRoot) {
             lines.push(`Next decay candidate: "${oldest.text}" (${oldest.age}d, decays at 90d)`);
           }
         }
+
+        const total = memory.corrected.length + memory.learned.length;
+        toast("Heartbeat", `${total} memories · ${logEntries.length} pending`);
 
         return lines.join("\n");
       },

--- a/.github/registry.json
+++ b/.github/registry.json
@@ -13,7 +13,7 @@
       "description": "Display rich HTML content in the browser with SSE live reload"
     },
     "heartbeat": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "path": ".github/extensions/heartbeat",
       "description": "Memory maintenance — consolidate session log to long-term memory, decay stale entries, reinforce active ones"
     }


### PR DESCRIPTION
Fires a native OS toast at the end of each heartbeat cycle via heartbeat_status.

- Windows: WinRT ToastNotificationManager
- macOS: osascript
- Linux: notify-send

Single toast per cycle showing memory count and pending log entries. No toasts on individual promote/decay operations.

Bumps heartbeat to 0.6.1.