### PR TITLE
feat: add rename support to upgrade system

### DIFF
--- a/.github/registry.json
+++ b/.github/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.10.1",
   "source": "ianphil/genesis",
   "extensions": {
     "cron": {
@@ -50,7 +50,7 @@
       "description": "SDK reference for building and debugging Copilot CLI extensions"
     },
     "upgrade": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "path": ".github/skills/upgrade",
       "description": "Pull new extensions and skills from the genesis template registry"
     }

--- a/.github/skills/upgrade/SKILL.md
+++ b/.github/skills/upgrade/SKILL.md
@@ -33,6 +33,7 @@ This outputs JSON with the diff:
   "new": [{"name": "foo", "type": "skill", "version": "0.2.0", "description": "..."}],
   "updated": [{"name": "daily-report", "type": "skill", "version": "0.2.0", "localVersion": "0.1.0", "description": "..."}],
   "current": [{"name": "commit", "type": "skill", "version": "0.1.0", "description": "..."}],
+  "renamed": [{"oldName": "code-exec", "newName": "bridge", "type": "extension", "version": "0.2.0", "localVersion": "0.1.2", "description": "..."}],
   "localOnly": []
 }
 ```
@@ -50,13 +51,14 @@ Format the JSON into a human-readable summary:
 
 📦 Extensions:
   🆕 cron v0.3.0 — Scheduled job execution
+  🔄 code-exec → bridge v0.2.0 — renamed
 
 📄 Skills:
   ✅ commit v0.3.0 — up to date
   ⬆️ daily-report v0.4.0 — update available (local: v0.3.0)
   🆕 copilot-extension v0.3.0 — SDK reference
 
-Install all new/updated? Or pick specific ones.
+Install all new/updated/renamed? Or pick specific ones.
 ```
 
 Use the `ask_user` tool to let the user select what to install.
@@ -88,6 +90,8 @@ Output JSON:
 }
 ```
 
+Items with `renamedFrom` indicate a rename was processed — the old directory was removed and the old registry entry deleted.
+
 ## Phase 4: Summary
 
 Format the install results:
@@ -104,6 +108,9 @@ Installed:
 Updated:
   📄 daily-report v0.3.0 → v0.4.0 — 1 file
 
+Renamed:
+  🔄 code-exec → bridge v0.2.0 — 9 files, old directory removed
+
 Local registry updated to v0.8.0.
 ```
 
@@ -117,6 +124,8 @@ If there are errors in the output, report them clearly and suggest retrying indi
 - **Never delete local-only items** — the script preserves them automatically
 - **Never modify files outside of `.github/extensions/` and `.github/skills/`** — the script only touches these paths
 - **Always show the diff before installing** — never auto-install without user confirmation
+- **Renames are destructive** — they delete the old directory. Always confirm with the user before installing a renamed item
+- **Old names auto-resolve** — if a user requests an old name (e.g. `code-exec`), the script resolves it to the new name via the `renames` map
 - **Skip items the user doesn't select** — respect their choices
 - **If `gh` CLI is not available**, report the error and stop — the script requires it
 - **If the script fails**, show the error output and suggest checking `gh auth status`

--- a/.github/skills/upgrade/upgrade.js
+++ b/.github/skills/upgrade/upgrade.js
@@ -93,40 +93,67 @@ function check() {
     new: [],
     updated: [],
     current: [],
+    renamed: [],
     localOnly: [],
   };
+
+  // Build rename lookup: oldName → newName, newName → oldName
+  const renames = remote.renames || {};
+  const reverseRenames = {};
+  for (const [oldName, newName] of Object.entries(renames)) {
+    reverseRenames[newName] = oldName;
+  }
 
   // Compare both extensions and skills
   for (const type of ["extensions", "skills"]) {
     const remoteItems = remote[type] || {};
     const localItems = local[type] || {};
+    const typeSingular = type === "extensions" ? "extension" : "skill";
 
     for (const [name, info] of Object.entries(remoteItems)) {
       const item = {
         name,
-        type: type === "extensions" ? "extension" : "skill",
+        type: typeSingular,
         version: info.version,
         path: info.path,
         description: info.description,
       };
 
-      if (!(name in localItems)) {
-        result.new.push(item);
-      } else if (compareSemver(info.version, localItems[name].version) > 0) {
-        result.updated.push({
-          ...item,
-          localVersion: localItems[name].version,
-        });
+      if (name in localItems) {
+        // Direct match — normal version comparison
+        if (compareSemver(info.version, localItems[name].version) > 0) {
+          result.updated.push({
+            ...item,
+            localVersion: localItems[name].version,
+          });
+        } else {
+          result.current.push(item);
+        }
       } else {
-        result.current.push(item);
+        // Not installed under this name — check if it's a rename
+        const oldName = reverseRenames[name];
+        if (oldName && oldName in localItems) {
+          result.renamed.push({
+            oldName,
+            newName: name,
+            type: typeSingular,
+            version: info.version,
+            localVersion: localItems[oldName].version,
+            description: info.description,
+          });
+        } else {
+          result.new.push(item);
+        }
       }
     }
 
     for (const [name, info] of Object.entries(localItems)) {
       if (!(name in remoteItems)) {
+        // Skip if this is the old name of a rename (already reported above)
+        if (name in renames) continue;
         result.localOnly.push({
           name,
-          type: type === "extensions" ? "extension" : "skill",
+          type: typeSingular,
           version: info.version,
           path: info.path,
           description: info.description,
@@ -170,6 +197,17 @@ function install(names) {
   };
 
   const requestedNames = new Set(names);
+
+  // Build rename lookup and resolve old names to new names
+  const renames = remote.renames || {};
+  const reverseRenames = {};
+  for (const [oldName, newName] of Object.entries(renames)) {
+    reverseRenames[newName] = oldName;
+    if (requestedNames.has(oldName)) {
+      requestedNames.delete(oldName);
+      requestedNames.add(newName);
+    }
+  }
 
   for (const type of ["extensions", "skills"]) {
     const remoteItems = remote[type] || {};
@@ -245,6 +283,22 @@ function install(names) {
           files: fileCount,
           npmInstalled,
         };
+
+        // Handle rename — clean up old directory and registry entry
+        const oldName = reverseRenames[name];
+        if (oldName) {
+          for (const t of ["extensions", "skills"]) {
+            if (local[t] && local[t][oldName]) {
+              const oldDir = path.join(root, local[t][oldName].path);
+              if (fs.existsSync(oldDir)) {
+                fs.rmSync(oldDir, { recursive: true, force: true });
+              }
+              delete local[t][oldName];
+              break;
+            }
+          }
+          entry.renamedFrom = oldName;
+        }
 
         if (isNew) {
           result.installed.push(entry);


### PR DESCRIPTION
upgrade.js check() detects renames via remote registry renames map, reports them as a distinct renamed[] category. install() auto-resolves old names to new, installs new files, deletes old directory, and updates local registry. SKILL.md updated with rename presentation.

Registry 0.10.0 → 0.10.1, upgrade skill 0.2.0 → 0.2.1.