### PR TITLE
feat: add branch field support to upgrade system

### DIFF
--- a/.github/registry.json
+++ b/.github/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.1",
+  "version": "0.10.2",
   "source": "ianphil/genesis",
   "extensions": {
     "cron": {
@@ -50,7 +50,7 @@
       "description": "SDK reference for building and debugging Copilot CLI extensions"
     },
     "upgrade": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "path": ".github/skills/upgrade",
       "description": "Pull new extensions and skills from the genesis template registry"
     }

--- a/.github/skills/upgrade/SKILL.md
+++ b/.github/skills/upgrade/SKILL.md
@@ -13,6 +13,7 @@ Check the genesis template for new or updated extensions and skills, then instal
 
 - `gh` CLI must be authenticated (`gh auth status`)
 - `.github/registry.json` must exist with a `source` field (e.g. `"source": "ianphil/genesis"`)
+- Optional `"branch"` field in `registry.json` to track a non-main branch (defaults to `"main"`)
 - If `registry.json` is missing or has no `source`, ask the user for the source repo (default: `ianphil/genesis`) and create it
 
 ## Phase 1: Check for Updates

--- a/.github/skills/upgrade/upgrade.js
+++ b/.github/skills/upgrade/upgrade.js
@@ -77,10 +77,11 @@ function check() {
   }
 
   const { owner, repo } = parseSource(local.source);
+  const branch = local.branch || "main";
 
   // Fetch remote registry
   const remoteRaw = gh(
-    `/repos/${owner}/${repo}/contents/.github/registry.json`
+    `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${branch}`
   );
   const remote = JSON.parse(
     Buffer.from(remoteRaw.content, "base64").toString("utf8")
@@ -171,17 +172,18 @@ function install(names) {
   const root = findRepoRoot();
   const local = readLocalRegistry(root);
   const { owner, repo } = parseSource(local.source);
+  const branch = local.branch || "main";
 
   // Fetch remote registry
   const remoteRaw = gh(
-    `/repos/${owner}/${repo}/contents/.github/registry.json`
+    `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${branch}`
   );
   const remote = JSON.parse(
     Buffer.from(remoteRaw.content, "base64").toString("utf8")
   );
 
   // Fetch full tree once
-  const tree = gh(`/repos/${owner}/${repo}/git/trees/main?recursive=1`);
+  const tree = gh(`/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`);
   const treeMap = new Map();
   for (const entry of tree.tree) {
     if (entry.type === "blob") {


### PR DESCRIPTION
check() and install() read optional branch field from local registry.json, defaulting to main. Allows tracking preview branches like insiders for testing.

Registry 0.10.1 → 0.10.2, upgrade skill 0.2.1 → 0.2.2.