### PR TITLE
feat: rename insiders channel to frontier

### DIFF
--- a/.github/skills/upgrade/SKILL.md
+++ b/.github/skills/upgrade/SKILL.md
@@ -14,7 +14,7 @@ Check the genesis template for new or updated extensions and skills, then instal
 - `gh` CLI must be authenticated (`gh auth status`)
 - `.github/registry.json` must exist with a `source` field (e.g. `"source": "ianphil/genesis"`)
 - Optional `"branch"` field in `registry.json` to track a non-main branch (defaults to `"main"`)
-- Optional `"channel"` field in `registry.json` to select a release channel (e.g. `"main"`, `"insiders"`). Takes precedence over `"branch"`. Defaults to `"main"`.
+- Optional `"channel"` field in `registry.json` to select a release channel (e.g. `"main"`, `"frontier"`). Takes precedence over `"branch"`. Defaults to `"main"`.
 - If `registry.json` is missing or has no `source`, ask the user for the source repo (default: `ianphil/genesis`) and create it
 
 ## Channels
@@ -22,17 +22,17 @@ Check the genesis template for new or updated extensions and skills, then instal
 Genesis publishes two release channels:
 
 - **main** — stable, minimal set (cron, canvas, commit, daily-report, upgrade)
-- **insiders** — superset of main with experimental extensions and skills
+- **frontier** — superset of main with experimental extensions and skills
 
 ### Switch channels
 
 ```bash
-node .github/skills/upgrade/upgrade.js channel insiders
+node .github/skills/upgrade/upgrade.js channel frontier
 ```
 
 This:
-- Sets `"channel": "insiders"` in the local registry
-- Fetches the remote registry from the `insiders` branch
+- Sets `"channel": "frontier"` in the local registry
+- Fetches the remote registry from the `frontier` branch
 - Returns a diff showing what items would be added or removed
 
 The output is the same format as `check` — present it to the user with the same UX. New items need `install`, removed items need `remove` or `pin`.
@@ -43,7 +43,7 @@ To switch back:
 node .github/skills/upgrade/upgrade.js channel main
 ```
 
-Items that only exist on insiders will appear as `removed`. The user can accept the removal or pin them to keep locally.
+Items that only exist on frontier will appear as `removed`. The user can accept the removal or pin them to keep locally.
 
 ### Already on target channel
 

--- a/.github/skills/upgrade/upgrade.js
+++ b/.github/skills/upgrade/upgrade.js
@@ -7,7 +7,7 @@
 //   node upgrade.js install name1,name2 — install/update selected items
 //   node upgrade.js remove name1,name2  — remove selected items from local
 //   node upgrade.js pin name1,name2     — pin items to prevent removal
-//   node upgrade.js channel <name>      — switch release channel (e.g. main, insiders)
+//   node upgrade.js channel <name>      — switch release channel (e.g. main, frontier)
 
 const { execSync } = require("child_process");
 const fs = require("fs");
@@ -611,7 +611,7 @@ if (require.main === module) {
       if (!args[0]) {
         console.error(
           JSON.stringify({
-            error: 'Usage: node upgrade.js channel <name> (e.g. "main", "insiders")',
+            error: 'Usage: node upgrade.js channel <name> (e.g. "main", "frontier")',
           })
         );
         process.exit(1);

--- a/.github/skills/upgrade/upgrade.test.js
+++ b/.github/skills/upgrade/upgrade.test.js
@@ -460,7 +460,7 @@ describe("resolveChannel", () => {
   });
 
   it("returns channel when set", () => {
-    assert.equal(resolveChannel({ channel: "insiders" }), "insiders");
+    assert.equal(resolveChannel({ channel: "frontier" }), "frontier");
   });
 
   it("falls back to branch when channel is not set", () => {
@@ -468,14 +468,14 @@ describe("resolveChannel", () => {
   });
 
   it("channel takes precedence over branch", () => {
-    assert.equal(resolveChannel({ channel: "insiders", branch: "develop" }), "insiders");
+    assert.equal(resolveChannel({ channel: "frontier", branch: "develop" }), "frontier");
   });
 });
 
 // ── diffRegistries — channel switching scenarios ─────────────────────────────
 
 describe("diffRegistries — channel switching", () => {
-  it("switching from main to insiders shows new items", () => {
+  it("switching from main to frontier shows new items", () => {
     const local = makeLocal({
       channel: "main",
       extensions: {
@@ -487,7 +487,7 @@ describe("diffRegistries — channel switching", () => {
         upgrade: { version: "0.4.0", path: ".github/skills/upgrade", description: "Upgrade" },
       },
     });
-    const insidersRemote = makeRemote({
+    const frontierRemote = makeRemote({
       extensions: {
         cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
         canvas: { version: "0.1.3", path: ".github/extensions/canvas", description: "Canvas" },
@@ -501,7 +501,7 @@ describe("diffRegistries — channel switching", () => {
       },
     });
 
-    const result = diffRegistries(local, insidersRemote);
+    const result = diffRegistries(local, frontierRemote);
 
     // Everything from main should be current
     assert.equal(result.current.length, 4);
@@ -513,9 +513,9 @@ describe("diffRegistries — channel switching", () => {
     assert.equal(result.removed.length, 0);
   });
 
-  it("switching from insiders to main shows removable items", () => {
+  it("switching from frontier to main shows removable items", () => {
     const local = makeLocal({
-      channel: "insiders",
+      channel: "frontier",
       extensions: {
         cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
         canvas: { version: "0.1.3", path: ".github/extensions/canvas", description: "Canvas" },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,38 +148,38 @@ Genesis publishes two release channels:
 | Channel | Branch | Contents | Audience |
 |---------|--------|----------|----------|
 | **main** | `main` | Stable extensions and skills only | All agents |
-| **insiders** | `insiders` | Everything in main + experimental items | Opt-in agents |
+| **frontier** | `frontier` | Everything in main + experimental items | Opt-in agents |
 
 ### How it works
 
 - `main` is the stable trunk — lean and reliable
-- `insiders` is a **superset** that always rebases on `main`
-- New extensions and skills land on `insiders` first
+- `frontier` is a **superset** that always rebases on `main`
+- New extensions and skills land on `frontier` first
 - When an item stabilizes, it graduates to `main` via PR
 
 ### Adding new items
 
-1. Create a feature branch from `insiders`
+1. Create a feature branch from `frontier`
 2. Add your extension or skill
 3. Update `registry.json` on your branch (add the new entry)
-4. PR into `insiders` — this makes it available to insiders agents on next upgrade
+4. PR into `frontier` — this makes it available to frontier agents on next upgrade
 
 ### Graduating items to main
 
-1. Confirm the item is stable (tested, no breaking changes, used by insiders agents)
-2. PR from `insiders` into `main` — include only the graduating item
+1. Confirm the item is stable (tested, no breaking changes, used by frontier agents)
+2. PR from `frontier` into `main` — include only the graduating item
 3. Update `main`'s `registry.json` to include the new entry
 4. Bump the registry version
 
 ### Branch management
 
-- **`insiders` always rebases on `main`** — never merge main into insiders
-- **Rebase insiders after every merge to main** — bug fixes, version bumps, docs updates, graduations. Small frequent rebases are painless; big ones after weeks of drift are not.
-- Keep the two registries consistent — main's items should always be a subset of insiders
+- **`frontier` always rebases on `main`** — never merge main into frontier
+- **Rebase frontier after every merge to main** — bug fixes, version bumps, docs updates, graduations. Small frequent rebases are painless; big ones after weeks of drift are not.
+- Keep the two registries consistent — main's items should always be a subset of frontier
 
 ```bash
 # After every merge to main:
-git checkout insiders
+git checkout frontier
 git rebase main
 git push --force-with-lease
 ```

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Minds evolve. New senses and skills can be pulled from the genesis registry at a
 
 No git remotes. No manual downloads. The mind upgrades itself through its own tools.
 
-### Insiders Channel
+### Frontier Channel
 
-Additional senses are available on the **insiders** channel for agents who want to live on the edge:
+Additional senses are available on the **frontier** channel for agents who want to push beyond the known map:
 
 | Extension | Sense |
 |-----------|-------|
@@ -70,7 +70,7 @@ Additional senses are available on the **insiders** channel for agents who want 
 | tunnel | **Reach** ...  expose local ports to the internet via Dev Tunnels |
 
 ```
-> Switch to insiders channel
+> Switch to frontier channel
 ```
 
 ## The Maze


### PR DESCRIPTION
Renames the experimental channel from 'insiders' to 'frontier' across all docs, upgrade skill, and tests. No logic changes.