### PR TITLE
feat: graduate responses extension to main

### DIFF
--- a/.github/extensions/responses/README.md
+++ b/.github/extensions/responses/README.md
@@ -1,0 +1,118 @@
+# Responses Extension
+
+Exposes the Copilot CLI agent as an OpenAI Responses API–compatible HTTP server,
+allowing external clients (web UIs, mobile apps, scripts, other agents) to
+interact with it using the standard OpenAI SDK.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/responses` | **OpenAI Responses API** ...  drop-in compatible |
+| `GET` | `/history?limit=N` | Retrieve conversation history (last N messages, or all if omitted) |
+| `GET` | `/health` | Liveness check |
+
+## OpenAI SDK Compatibility
+
+Any client that speaks the OpenAI Responses API can talk to your agent:
+
+```typescript
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  baseURL: 'http://127.0.0.1:<port>/v1',
+  apiKey: 'unused',           // no auth required for localhost
+});
+
+// Non-streaming
+const response = await client.responses.create({
+  model: 'copilot',           // ignored ...  agent picks its own model
+  input: 'What PRs need review?',
+});
+console.log(response.output_text);
+
+// Streaming
+const stream = await client.responses.create({
+  model: 'copilot',
+  input: 'Explain this codebase',
+  stream: true,
+});
+for await (const event of stream) {
+  if (event.type === 'response.output_text.delta') {
+    process.stdout.write(event.delta);
+  }
+}
+```
+
+### Request format
+
+```json
+{
+  "model": "copilot",
+  "input": "Your prompt here",
+  "instructions": "Optional system instructions",
+  "stream": false
+}
+```
+
+`input` accepts a string or an array of `{ role, content }` conversation items.
+`instructions` is prepended as system context. `stream: true` enables SSE.
+
+## Usage
+
+The extension starts automatically when the Copilot CLI session begins. The
+port is logged to stderr and available via the `responses_status` tool.
+
+### Send a message (curl)
+
+```bash
+curl -s -X POST http://127.0.0.1:<port>/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"What files are in this repo?"}'
+```
+
+### Stream a response
+
+```bash
+curl -N -X POST http://127.0.0.1:<port>/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"Hello!","stream":true}'
+```
+
+### Health check
+
+```bash
+curl http://127.0.0.1:<port>/health
+```
+
+## Agent Tools
+
+| Tool | Description |
+|------|-------------|
+| `responses_status` | Show server status, port, and endpoints |
+| `responses_restart` | Restart the server (optionally on a specific port) |
+
+## Architecture
+
+```
+External Client ──POST /v1/responses──▶ HTTP Server (Node.js)
+                                             │
+                                       session.sendAndWait()
+                                             │
+                                       Copilot Agent ──▶ tools, files, etc.
+                                             │
+                                       response.data.content
+                                             │
+External Client ◀──OpenAI JSON──────── HTTP Server
+```
+
+## Security
+
+The server binds to `127.0.0.1` (localhost only). It is **not** exposed to the
+network. CORS headers allow all origins for local development convenience.
+
+For production use, consider adding:
+- Authentication (API key header)
+- Rate limiting
+- Request size limits
+- TLS termination via a reverse proxy

--- a/.github/extensions/responses/extension.mjs
+++ b/.github/extensions/responses/extension.mjs
@@ -1,0 +1,45 @@
+import { approveAll } from "@github/copilot-sdk";
+import { joinSession } from "@github/copilot-sdk/extension";
+import { createChatApiServer } from "./lib/server.mjs";
+import { createApiTools } from "./tools/api-tools.mjs";
+
+// Bind session methods lazily — they're set once joinSession completes
+const deps = {
+  sendAndWait: null,
+  send: null,
+  getMessages: null,
+  onEvent: null,
+};
+
+const DEFAULT_PORT = 15210;
+
+const server = createChatApiServer({
+  sendAndWait: (...a) => deps.sendAndWait(...a),
+  send: (...a) => deps.send(...a),
+  getMessages: (...a) => deps.getMessages(...a),
+  onEvent: (...a) => deps.onEvent(...a),
+});
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+
+  hooks: {
+    onSessionStart: async () => {
+      const port = await server.start(DEFAULT_PORT);
+      console.error(`responses: listening on http://127.0.0.1:${port}`);
+    },
+
+    onSessionEnd: async () => {
+      await server.stop();
+      console.error("responses: server stopped");
+    },
+  },
+
+  tools: createApiTools(server, DEFAULT_PORT),
+});
+
+// Wire up session methods now that joinSession has resolved
+deps.sendAndWait = session.sendAndWait.bind(session);
+deps.send = session.send.bind(session);
+deps.getMessages = session.getMessages.bind(session);
+deps.onEvent = session.on.bind(session);

--- a/.github/extensions/responses/lib/responses.mjs
+++ b/.github/extensions/responses/lib/responses.mjs
@@ -1,0 +1,273 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Translates between OpenAI Responses API format and the Copilot session.
+ *
+ * Supports:
+ *   - POST /v1/responses  (non-streaming + streaming)
+ *   - Normalizes input (string or conversation array) to a prompt string
+ *   - Wraps agent output in the OpenAI response envelope
+ *   - Emits proper SSE event sequence for streaming
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function responseId() {
+  return `resp_${randomUUID().replace(/-/g, "")}`;
+}
+
+function messageId() {
+  return `msg_${randomUUID().replace(/-/g, "")}`;
+}
+
+function nowUnix() {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Normalize the `input` field into a plain prompt string.
+ * Accepts:
+ *   - string
+ *   - array of { role, content } conversation items (takes the last user message)
+ */
+export function normalizeInput(input, instructions) {
+  let prompt = "";
+
+  if (typeof input === "string") {
+    prompt = input;
+  } else if (Array.isArray(input)) {
+    // Collect user messages; use the last one as the prompt
+    const parts = [];
+    for (const item of input) {
+      if (typeof item === "string") {
+        parts.push(item);
+      } else if (item.content) {
+        const text =
+          typeof item.content === "string"
+            ? item.content
+            : Array.isArray(item.content)
+              ? item.content
+                  .filter((c) => c.type === "input_text" || c.type === "text")
+                  .map((c) => c.text)
+                  .join("\n")
+              : String(item.content);
+        parts.push(text);
+      }
+    }
+    prompt = parts.join("\n\n");
+  }
+
+  // Prepend instructions if provided
+  if (instructions && typeof instructions === "string") {
+    prompt = `[System instructions: ${instructions}]\n\n${prompt}`;
+  }
+
+  return prompt;
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming response builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a complete OpenAI Responses API response object.
+ */
+export function buildResponse(content, opts = {}) {
+  const id = opts.id || responseId();
+  const model = opts.model || "copilot-agent";
+
+  return {
+    id,
+    object: "response",
+    created_at: nowUnix(),
+    status: "completed",
+    model,
+    output: [
+      {
+        type: "message",
+        id: messageId(),
+        status: "completed",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: content,
+          },
+        ],
+      },
+    ],
+    output_text: content,
+    parallel_tool_calls: false,
+    previous_response_id: opts.previousResponseId || null,
+    reasoning: null,
+    store: false,
+    temperature: opts.temperature ?? 1.0,
+    text: { format: { type: "text" } },
+    tool_choice: "auto",
+    tools: [],
+    top_p: 1.0,
+    usage: null,
+    metadata: opts.metadata || {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Streaming helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a single SSE event to the response stream.
+ */
+function sseEvent(res, eventType, data) {
+  res.write(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+/**
+ * Create a streaming handler that emits OpenAI Responses API SSE events.
+ *
+ * Event sequence:
+ *   1. response.created
+ *   2. response.output_item.added
+ *   3. response.content_part.added
+ *   4. response.output_text.delta  (repeated)
+ *   5. response.content_part.done
+ *   6. response.output_item.done
+ *   7. response.completed
+ */
+export function createStreamWriter(res, opts = {}) {
+  const id = opts.id || responseId();
+  const msgId = messageId();
+  const model = opts.model || "copilot-agent";
+  const createdAt = nowUnix();
+  let accumulatedText = "";
+  let sequenceNumber = 0;
+
+  // Write SSE headers
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  });
+
+  const baseResponse = {
+    id,
+    object: "response",
+    created_at: createdAt,
+    status: "in_progress",
+    model,
+    output: [],
+    output_text: "",
+    parallel_tool_calls: false,
+    previous_response_id: opts.previousResponseId || null,
+    reasoning: null,
+    store: false,
+    temperature: opts.temperature ?? 1.0,
+    text: { format: { type: "text" } },
+    tool_choice: "auto",
+    tools: [],
+    top_p: 1.0,
+    usage: null,
+    metadata: opts.metadata || {},
+  };
+
+  // 1. response.created
+  sseEvent(res, "response.created", baseResponse);
+
+  // 2. response.output_item.added
+  const outputItem = {
+    type: "message",
+    id: msgId,
+    status: "in_progress",
+    role: "assistant",
+    content: [],
+  };
+  sseEvent(res, "response.output_item.added", {
+    output_index: 0,
+    item: outputItem,
+    sequence_number: sequenceNumber++,
+  });
+
+  // 3. response.content_part.added
+  const contentPart = { type: "output_text", text: "" };
+  sseEvent(res, "response.content_part.added", {
+    output_index: 0,
+    content_index: 0,
+    part: contentPart,
+    sequence_number: sequenceNumber++,
+  });
+
+  return {
+    /** Emit a text delta chunk. */
+    writeDelta(text) {
+      if (!text) return;
+      accumulatedText += text;
+      sseEvent(res, "response.output_text.delta", {
+        output_index: 0,
+        content_index: 0,
+        delta: text,
+        sequence_number: sequenceNumber++,
+      });
+    },
+
+    /** Finalize the stream with a completed response. */
+    complete() {
+      // content_part.done
+      sseEvent(res, "response.content_part.done", {
+        output_index: 0,
+        content_index: 0,
+        part: { type: "output_text", text: accumulatedText },
+        sequence_number: sequenceNumber++,
+      });
+
+      // output_item.done
+      sseEvent(res, "response.output_item.done", {
+        output_index: 0,
+        item: {
+          type: "message",
+          id: msgId,
+          status: "completed",
+          role: "assistant",
+          content: [{ type: "output_text", text: accumulatedText }],
+        },
+        sequence_number: sequenceNumber++,
+      });
+
+      // response.completed
+      sseEvent(res, "response.completed", {
+        ...baseResponse,
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: msgId,
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", text: accumulatedText }],
+          },
+        ],
+        output_text: accumulatedText,
+      });
+
+      res.end();
+    },
+
+    /** Emit an error and close the stream. */
+    error(message) {
+      sseEvent(res, "error", {
+        type: "server_error",
+        message,
+      });
+      res.end();
+    },
+
+    /** Get accumulated text so far. */
+    getText() {
+      return accumulatedText;
+    },
+  };
+}

--- a/.github/extensions/responses/lib/server.mjs
+++ b/.github/extensions/responses/lib/server.mjs
@@ -1,0 +1,243 @@
+import { createServer } from "node:http";
+import {
+  normalizeInput,
+  buildResponse,
+  createStreamWriter,
+} from "./responses.mjs";
+
+/**
+ * Creates an HTTP server that bridges external clients to the Copilot session
+ * via an OpenAI Responses API–compatible interface.
+ *
+ * Endpoints:
+ *   POST /v1/responses  — OpenAI Responses API (compatible)
+ *   GET  /health        — liveness check
+ *   GET  /history       — recent conversation history
+ *
+ * @param {object} deps
+ * @param {Function} deps.sendAndWait  — session.sendAndWait bound to the active session
+ * @param {Function} deps.send         — session.send bound to the active session
+ * @param {Function} deps.getMessages  — session.getMessages bound to the active session
+ * @param {Function} deps.onEvent      — session.on bound to the active session
+ */
+export function createChatApiServer(deps) {
+  let server = null;
+  let port = null;
+  const sseClients = [];
+
+  function corsHeaders() {
+    return {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    };
+  }
+
+  function jsonResponse(res, status, body) {
+    const payload = JSON.stringify(body);
+    res.writeHead(status, {
+      ...corsHeaders(),
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload),
+    });
+    res.end(payload);
+  }
+
+  function readBody(req) {
+    return new Promise((resolve, reject) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString()));
+        } catch {
+          reject(new Error("invalid json"));
+        }
+      });
+      req.on("error", reject);
+    });
+  }
+
+  async function handleHistory(req, res) {
+    try {
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const limit = parseInt(url.searchParams.get("limit"), 10) || 0;
+      let messages = await deps.getMessages();
+      if (limit > 0) {
+        messages = messages.slice(-limit);
+      }
+      jsonResponse(res, 200, { messages });
+    } catch (err) {
+      jsonResponse(res, 500, { error: err.message });
+    }
+  }
+
+  function handleHealth(_req, res) {
+    jsonResponse(res, 200, {
+      status: "ok",
+      port,
+      uptime: process.uptime(),
+      timestamp: Date.now(),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // OpenAI Responses API — POST /v1/responses
+  // ---------------------------------------------------------------------------
+
+  async function handleResponses(req, res) {
+    let body;
+    try {
+      body = await readBody(req);
+    } catch {
+      return jsonResponse(res, 400, {
+        error: { type: "invalid_request_error", message: "Invalid JSON body" },
+      });
+    }
+
+    const input = body.input;
+    if (input === undefined || input === null) {
+      return jsonResponse(res, 400, {
+        error: {
+          type: "invalid_request_error",
+          message: "Missing required field: input",
+        },
+      });
+    }
+
+    const prompt = normalizeInput(input, body.instructions);
+    const opts = {
+      model: body.model,
+      previousResponseId: body.previous_response_id,
+      temperature: body.temperature,
+      metadata: body.metadata,
+    };
+
+    // --- Streaming ---
+    if (body.stream === true) {
+      const writer = createStreamWriter(res, opts);
+      const unsubs = [];
+
+      const offDelta = deps.onEvent("assistant.streaming_delta", (event) => {
+        const chunk = event?.data?.content || event?.data?.delta || "";
+        if (chunk) writer.writeDelta(chunk);
+      });
+      unsubs.push(offDelta);
+
+      let finalContent = "";
+      const done = new Promise((resolve) => {
+        const offMessage = deps.onEvent("assistant.message", (event) => {
+          finalContent = event?.data?.content ?? "";
+          resolve();
+        });
+        unsubs.push(offMessage);
+      });
+
+      try {
+        await deps.send({ prompt });
+      } catch (err) {
+        unsubs.forEach((fn) => fn());
+        return writer.error(err.message);
+      }
+
+      const timeout = setTimeout(() => {
+        unsubs.forEach((fn) => fn());
+        writer.error("Request timed out");
+      }, 300_000);
+
+      req.on("close", () => {
+        clearTimeout(timeout);
+        unsubs.forEach((fn) => fn());
+      });
+
+      await done;
+      clearTimeout(timeout);
+      unsubs.forEach((fn) => fn());
+
+      // If no streaming deltas were captured (SDK may not propagate them
+      // to extensions), emit the full response as a single delta so the
+      // client still gets content.
+      if (!writer.getText() && finalContent) {
+        writer.writeDelta(finalContent);
+      }
+
+      writer.complete();
+      return;
+    }
+
+    // --- Non-streaming ---
+    const timeout = typeof body.timeout === "number" ? body.timeout : 120_000;
+
+    try {
+      const response = await deps.sendAndWait({ prompt }, timeout);
+      const content = response?.data?.content ?? "(no response)";
+      jsonResponse(res, 200, buildResponse(content, opts));
+    } catch (err) {
+      jsonResponse(res, 502, {
+        error: {
+          type: "server_error",
+          message: "Agent failed to respond",
+          detail: err.message,
+        },
+      });
+    }
+  }
+
+  function handleRequest(req, res) {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const path = url.pathname;
+
+    // CORS preflight
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, corsHeaders());
+      return res.end();
+    }
+
+    if (path === "/health" && req.method === "GET") return handleHealth(req, res);
+    if (path === "/history" && req.method === "GET") return handleHistory(req, res);
+    if (path === "/v1/responses" && req.method === "POST") return handleResponses(req, res);
+
+    jsonResponse(res, 404, {
+      error: "Not found",
+      endpoints: {
+        "POST /v1/responses": "OpenAI Responses API (compatible)",
+        "GET /history?limit=N": "Conversation history (last N messages, or all)",
+        "GET /health": "Health check",
+      },
+    });
+  }
+
+  return {
+    start(requestedPort = 0) {
+      return new Promise((resolve, reject) => {
+        server = createServer(handleRequest);
+        server.listen(requestedPort, "127.0.0.1", () => {
+          port = server.address().port;
+          resolve(port);
+        });
+        server.on("error", reject);
+      });
+    },
+
+    stop() {
+      return new Promise((resolve) => {
+        if (!server) return resolve();
+        sseClients.forEach((c) => c.end());
+        sseClients.length = 0;
+        server.close(() => {
+          server = null;
+          port = null;
+          resolve();
+        });
+      });
+    },
+
+    getPort() {
+      return port;
+    },
+
+    isRunning() {
+      return server !== null;
+    },
+  };
+}

--- a/.github/extensions/responses/package.json
+++ b/.github/extensions/responses/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "copilot-responses-extension",
+  "private": true,
+  "type": "module"
+}

--- a/.github/extensions/responses/tools/api-tools.mjs
+++ b/.github/extensions/responses/tools/api-tools.mjs
@@ -1,0 +1,55 @@
+/**
+ * Tools exposed to the agent for managing the Responses API server.
+ */
+export function createApiTools(server, defaultPort = 15210) {
+  return [
+    {
+      name: "responses_status",
+      description:
+        "Get the status of the Responses API server, including its port and whether it is running.",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      handler: async () => {
+        const running = server.isRunning();
+        const port = server.getPort();
+        if (!running) {
+          return "Responses API server is not running.";
+        }
+        return [
+          `Responses API server is running on http://127.0.0.1:${port}`,
+          "",
+          "Endpoints:",
+          `  POST http://127.0.0.1:${port}/v1/responses  — OpenAI Responses API (compatible)`,
+          `  POST http://127.0.0.1:${port}/chat          — send a message, get a response`,
+          `  GET  http://127.0.0.1:${port}/chat/stream   — SSE stream (query: ?prompt=...)`,
+          `  GET  http://127.0.0.1:${port}/history        — conversation history`,
+          `  GET  http://127.0.0.1:${port}/health         — health check`,
+        ].join("\n");
+      },
+    },
+    {
+      name: "responses_restart",
+      description:
+        "Restart the Responses API server. Use if the server becomes unresponsive.",
+      parameters: {
+        type: "object",
+        properties: {
+          port: {
+            type: "number",
+            description:
+              `Port to bind to. Defaults to ${defaultPort}.`,
+          },
+        },
+      },
+      handler: async (args) => {
+        if (server.isRunning()) {
+          await server.stop();
+        }
+        const actualPort = await server.start(args.port || defaultPort);
+        return `Responses API server restarted on http://127.0.0.1:${actualPort}`;
+      },
+    },
+  ];
+}

--- a/.github/registry.json
+++ b/.github/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.13.0",
+  "version": "0.14.0",
   "source": "ianphil/genesis",
   "channel": "main",
   "extensions": {
@@ -12,6 +12,11 @@
       "version": "0.1.3",
       "path": ".github/extensions/canvas",
       "description": "Display rich HTML content in the browser with SSE live reload"
+    },
+    "responses": {
+      "version": "0.1.0",
+      "path": ".github/extensions/responses",
+      "description": "OpenAI Responses API–compatible HTTP server — external chat interfaces talk to the agent via standard SDK"
     }
   },
   "skills": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ This document is written for AI agents contributing to the codebase. If you are 
 .github/
   extensions/     # Copilot CLI extensions (tools the agent can use)
   skills/         # Skills (markdown instructions + scripts)
+    new-mind/templates/  # Genesis templates (soul, agent file, etc.)
   registry.json   # Version manifest — tracks what's installed
   agents/         # Agent definition files
   copilot-instructions.md  # Bootstrap instructions (consumed during genesis)
-.genesis-temp/    # Templates consumed during bootstrap (not shipped to agents)
 .working-memory/  # Stub files — overwritten during agent bootstrap
 ```
 
@@ -167,9 +167,11 @@ Genesis publishes two release channels:
 ### Graduating items to main
 
 1. Confirm the item is stable (tested, no breaking changes, used by frontier agents)
-2. PR from `frontier` into `main` — include only the graduating item
-3. Update `main`'s `registry.json` to include the new entry
-4. Bump the registry version
+2. Create a feature branch from `main`: `git checkout main && git checkout -b feature/graduate-<name>`
+3. Pull only the graduating item: `git checkout frontier -- .github/extensions/<name>/` (or `skills/`)
+4. Add the entry to `registry.json` and bump the version
+5. Commit, push, and open a PR against `main`
+6. After merge, rebase frontier on main (see below) — expect a conflict on `registry.json`; resolve by keeping frontier's extra items with main's new version number
 
 ### Branch management
 


### PR DESCRIPTION
## What
Promotes the **responses** extension (v0.1.0) from frontier to the stable main channel.

## What's included
- \.github/extensions/responses/\ — OpenAI Responses API-compatible HTTP server (6 files)
- \egistry.json\ bump: 0.13.0 → 0.14.0
- \CONTRIBUTING.md\ — updated graduation steps

## Post-merge
Rebase frontier on main and resolve the expected \egistry.json\ conflict.