### PR TITLE
feat: graduate packages skill to main

### DIFF
--- a/.github/registry.json
+++ b/.github/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.14.0",
+  "version": "0.15.0",
   "source": "ianphil/genesis",
   "channel": "main",
   "extensions": {
@@ -34,6 +34,12 @@
       "version": "0.4.0",
       "path": ".github/skills/upgrade",
       "description": "Pull new extensions and skills from the genesis template registry"
+    },
+    "packages": {
+      "version": "0.1.0",
+      "path": ".github/skills/packages",
+      "description": "Install, remove, and manage extensions and skills from third-party Genesis packages"
     }
-  }
+  },
+  "packages": []
 }

--- a/.github/skills/packages/SKILL.md
+++ b/.github/skills/packages/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: packages
+description: Install, remove, and manage extensions and skills from third-party Genesis packages. Use when the user asks to install a package from another repo, list installed packages, remove a third-party package, or check for updates from a specific package source.
+---
+
+# Genesis Packages
+
+Install extensions and skills from any GitHub repository that follows the Genesis package format.
+
+**This skill includes `packages.js`** — a script that handles registry lookups, file downloads, conflict detection, and registry updates. Your job is to run it and handle UX.
+
+## Prerequisites
+
+- `gh` CLI must be authenticated (`gh auth status`)
+- `.github/registry.json` must exist (created during genesis bootstrap)
+- The target package repo must have a `.github/registry.json` following the Genesis registry format
+
+## What is a Genesis Package
+
+A Genesis package is any GitHub repository that contains a `.github/registry.json` declaring extensions and/or skills. Package authors add the `genesis-package` topic to their repo for discoverability.
+
+Packages are referenced as `owner/repo` (e.g. `someuser/cool-extensions`). An optional `@ref` pins to a specific tag or branch (e.g. `someuser/cool-extensions@v1.0.0`).
+
+## Natural Language Triggers
+
+- "install the weather extension from someuser/cool-extensions"
+- "install package from someuser/cool-extensions@v1.0.0"
+- "what packages are installed?"
+- "remove the someuser/cool-extensions package"
+- "check for updates from someuser/cool-extensions"
+- "what's available in someuser/cool-extensions?"
+
+## Commands
+
+### Search — browse what a package offers
+
+```bash
+node .github/skills/packages/packages.js search someuser/cool-extensions
+node .github/skills/packages/packages.js search someuser/cool-extensions@v1.0.0
+```
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "ref": "main",
+  "version": "0.3.0",
+  "extensions": [
+    {"name": "weather", "version": "0.1.0", "description": "Weather data lookups"}
+  ],
+  "skills": []
+}
+```
+
+Present this as a readable list. Ask the user which items they want to install.
+
+### Install — add items from a package
+
+```bash
+node .github/skills/packages/packages.js install someuser/cool-extensions
+node .github/skills/packages/packages.js install someuser/cool-extensions@v1.0.0
+node .github/skills/packages/packages.js install someuser/cool-extensions --ref v1.0.0
+node .github/skills/packages/packages.js install someuser/cool-extensions --items weather,forecast
+```
+
+This:
+- Fetches the remote `.github/registry.json`
+- Downloads files for each requested item (all items if `--items` not specified)
+- Runs `npm install --production` if `package.json` exists in an item's directory
+- Updates `.github/registry.json`: adds to `packages[]` array AND merges into top-level `extensions`/`skills` with a `package` field
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "ref": "main",
+  "installed": [{"name": "weather", "type": "extension", "version": "0.1.0", "files": 3, "npmInstalled": false}],
+  "updated": [],
+  "skipped": [],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+Items in `skipped` have a `reason` — typically a conflict with an existing extension or skill. Always report skipped items to the user.
+
+### Remove — uninstall items from a package
+
+```bash
+node .github/skills/packages/packages.js remove someuser/cool-extensions
+node .github/skills/packages/packages.js remove someuser/cool-extensions --items weather
+```
+
+This:
+- Removes files from disk (staged removal for safety)
+- Cleans up registry entries from both `packages[]` and top-level `extensions`/`skills`
+- If all items from a package are removed, removes the package entry entirely
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "removed": [{"name": "weather", "type": "extension", "version": "0.1.0", "path": ".github/extensions/weather"}],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+### List — show all installed packages
+
+```bash
+node .github/skills/packages/packages.js list
+```
+
+Output JSON (array):
+
+```json
+[
+  {
+    "source": "someuser/cool-extensions",
+    "ref": "v1.0.0",
+    "extensions": [{"name": "weather", "version": "0.1.0", "description": "Weather data lookups"}],
+    "skills": []
+  }
+]
+```
+
+Present as a readable summary. If the array is empty, say "No third-party packages installed."
+
+### Check — compare installed vs remote versions
+
+```bash
+node .github/skills/packages/packages.js check someuser/cool-extensions
+node .github/skills/packages/packages.js check someuser/cool-extensions --ref v2.0.0
+```
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "ref": "main",
+  "remoteVersion": "0.4.0",
+  "updates": [
+    {"name": "weather", "type": "extension", "localVersion": "0.1.0", "remoteVersion": "0.2.0", "status": "update_available"}
+  ],
+  "new": [],
+  "current": [],
+  "notInstalled": false
+}
+```
+
+Status values:
+- `update_available` — newer version exists on remote
+- `removed_upstream` — item no longer exists on remote
+
+If `notInstalled` is true, the package has never been installed — all remote items appear in `new`.
+
+Present as a readable summary with available updates highlighted. If updates exist, ask the user if they want to install them using `install --items name1,name2`.
+
+## Presenting Results
+
+### After install
+
+```
+═══════════════════════════════════════════
+  ✅ PACKAGE INSTALLED
+  Source: someuser/cool-extensions@main
+═══════════════════════════════════════════
+
+Installed:
+  📦 weather v0.1.0 — 3 files
+
+Registry updated.
+```
+
+If there were skipped items:
+```
+⚠️  Skipped (conflict):
+  weather — extension "weather" already exists (origin: ianphil/genesis)
+```
+
+If extensions were installed, remind the user:
+> "New extensions installed. Restart your Copilot session to activate them."
+
+### After remove
+
+```
+Removed:
+  🗑️ weather v0.1.0 — directory deleted
+```
+
+### After list (with packages)
+
+```
+Installed packages:
+
+  someuser/cool-extensions @ v1.0.0
+    📦 weather v0.1.0 — Weather data lookups
+```
+
+### After check (with updates)
+
+```
+Updates available from someuser/cool-extensions:
+  ⬆️ weather v0.1.0 → v0.2.0
+```
+
+## Rules
+
+- **Always confirm before removing** — removals delete directories from disk
+- **Never silently overwrite** — if a conflict is detected, report it and skip the item
+- **Template items are authoritative** — packages cannot overwrite extensions or skills from the genesis template source
+- **Always show search results before installing** — let the user see what's available and select items
+- **Conflict = skip, not fail** — a conflict on one item doesn't block other items from installing
+- **If `gh` CLI is not available**, report the error and stop
+- **If the script fails**, show the error output and suggest checking `gh auth status`

--- a/.github/skills/packages/packages.js
+++ b/.github/skills/packages/packages.js
@@ -1,0 +1,671 @@
+#!/usr/bin/env node
+// packages.js — Install extensions and skills from third-party Genesis packages.
+// Zero dependencies. Requires: Node.js 18+, gh CLI authenticated.
+//
+// Usage:
+//   node packages.js search <owner/repo[@ref]>               — list available items
+//   node packages.js install <owner/repo[@ref]> [--ref <r>] [--items a,b] — install items
+//   node packages.js remove <owner/repo> [--items a,b]       — remove installed items
+//   node packages.js list                                     — list all installed packages
+//   node packages.js check <owner/repo[@ref]> [--ref <r>]    — compare installed vs remote
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function gh(apiPath) {
+  const raw = execSync(`gh api ${apiPath}`, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return JSON.parse(raw);
+}
+
+function ghBlob(owner, repo, sha) {
+  const blob = gh(`/repos/${owner}/${repo}/git/blobs/${sha}`);
+  return Buffer.from(blob.content, "base64");
+}
+
+function compareSemver(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1;
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1;
+  }
+  return 0;
+}
+
+function findRepoRoot() {
+  let dir = process.cwd();
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, ".github", "registry.json"))) return dir;
+    dir = path.dirname(dir);
+  }
+  return process.cwd();
+}
+
+function readLocalRegistry(root) {
+  const p = path.join(root, ".github", "registry.json");
+  if (!fs.existsSync(p)) {
+    return { version: "0.0.0", source: "", extensions: {}, skills: {}, packages: [] };
+  }
+  const reg = JSON.parse(fs.readFileSync(p, "utf8"));
+  if (!Array.isArray(reg.packages)) reg.packages = [];
+  return reg;
+}
+
+function writeLocalRegistry(root, registry) {
+  const p = path.join(root, ".github", "registry.json");
+  fs.writeFileSync(p, JSON.stringify(registry, null, 2) + "\n", "utf8");
+}
+
+function makeStagedRemovalPath(itemDir) {
+  const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return path.join(
+    path.dirname(itemDir),
+    `${path.basename(itemDir)}.remove-${suffix}`
+  );
+}
+
+// ── Pure logic (testable) ────────────────────────────────────────────────────
+
+// Parse "owner/repo" or "owner/repo@ref" into { owner, repo, ref }
+function parsePackageSource(source) {
+  const atIdx = source.indexOf("@");
+  let repoStr = source;
+  let ref = null;
+
+  if (atIdx !== -1) {
+    repoStr = source.slice(0, atIdx);
+    ref = source.slice(atIdx + 1);
+  }
+
+  const slashIdx = repoStr.indexOf("/");
+  if (slashIdx === -1 || slashIdx === 0 || slashIdx === repoStr.length - 1) {
+    throw new Error(
+      `Invalid package source "${source}". Expected "owner/repo" or "owner/repo@ref".`
+    );
+  }
+
+  return {
+    owner: repoStr.slice(0, slashIdx),
+    repo: repoStr.slice(slashIdx + 1),
+    ref,
+  };
+}
+
+// Find an installed package entry by source (owner/repo), ignoring ref
+function findInstalledPackage(registry, ownerRepo) {
+  return (registry.packages || []).find((p) => p.source === ownerRepo) || null;
+}
+
+// Detect conflicts between items about to be installed and what's already in the registry.
+// Returns an array of conflict descriptions (strings).
+function detectConflicts(registry, itemsByType, packageSource) {
+  const conflicts = [];
+
+  for (const type of ["extensions", "skills"]) {
+    const incoming = itemsByType[type] || {};
+    const existing = registry[type] || {};
+
+    for (const name of Object.keys(incoming)) {
+      if (name in existing) {
+        const origin = existing[name].package || registry.source || "template";
+        if (origin !== packageSource) {
+          conflicts.push(
+            `${type.slice(0, -1)} "${name}" already exists (origin: ${origin})`
+          );
+        }
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+// Merge package items into top-level registry extensions/skills with a `package` field
+function mergeIntoTopLevel(registry, packageSource, installedByType) {
+  for (const type of ["extensions", "skills"]) {
+    if (!registry[type]) registry[type] = {};
+    for (const [name, info] of Object.entries(installedByType[type] || {})) {
+      registry[type][name] = { ...info, package: packageSource };
+    }
+  }
+}
+
+// Remove package items from top-level registry
+function removeFromTopLevel(registry, packageSource, names) {
+  for (const type of ["extensions", "skills"]) {
+    const items = registry[type] || {};
+    for (const name of names) {
+      if (name in items && items[name].package === packageSource) {
+        delete items[name];
+      }
+    }
+  }
+}
+
+// Build the list output for installed packages
+function buildListOutput(registry) {
+  return (registry.packages || []).map((pkg) => ({
+    source: pkg.source,
+    ref: pkg.ref || null,
+    extensions: Object.entries(pkg.installed.extensions || {}).map(
+      ([name, info]) => ({ name, version: info.version, description: info.description })
+    ),
+    skills: Object.entries(pkg.installed.skills || {}).map(
+      ([name, info]) => ({ name, version: info.version, description: info.description })
+    ),
+  }));
+}
+
+// ── Search command ────────────────────────────────────────────────────────────
+
+function search(rawSource) {
+  const { owner, repo, ref: parsedRef } = parsePackageSource(rawSource);
+  const ref = parsedRef || "main";
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${ref}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from ${owner}/${repo}@${ref}: ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  const result = {
+    source: `${owner}/${repo}`,
+    ref,
+    version: remote.version,
+    extensions: Object.entries(remote.extensions || {}).map(([name, info]) => ({
+      name,
+      version: info.version,
+      description: info.description,
+    })),
+    skills: Object.entries(remote.skills || {}).map(([name, info]) => ({
+      name,
+      version: info.version,
+      description: info.description,
+    })),
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Install command ───────────────────────────────────────────────────────────
+
+function install(rawSource, opts) {
+  const { owner, repo, ref: parsedRef } = parsePackageSource(rawSource);
+  const ref = opts.ref || parsedRef || "main";
+  const requestedItems = opts.items ? new Set(opts.items) : null;
+
+  const root = opts.root || findRepoRoot();
+  const local = readLocalRegistry(root);
+  const ownerRepo = `${owner}/${repo}`;
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${ref}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from ${ownerRepo}@${ref}: ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  // Collect the items to install
+  const toInstallByType = { extensions: {}, skills: {} };
+  for (const type of ["extensions", "skills"]) {
+    for (const [name, info] of Object.entries(remote[type] || {})) {
+      if (requestedItems === null || requestedItems.has(name)) {
+        toInstallByType[type][name] = info;
+      }
+    }
+  }
+
+  // Conflict detection — skip items that already exist from a different origin
+  const conflicts = detectConflicts(local, toInstallByType, ownerRepo);
+  const conflictNames = new Set(
+    conflicts.map((c) => c.match(/"([^"]+)"/)?.[1]).filter(Boolean)
+  );
+
+  const result = {
+    source: ownerRepo,
+    ref,
+    installed: [],
+    updated: [],
+    skipped: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  // Report conflicts as skipped
+  for (const conflict of conflicts) {
+    const name = conflict.match(/"([^"]+)"/)?.[1] || "unknown";
+    result.skipped.push({ name, reason: conflict });
+  }
+
+  // Fetch tree once for file downloads
+  let treeMap = new Map();
+  if (Object.values(toInstallByType).some((t) => Object.keys(t).length > 0)) {
+    try {
+      const tree = gh(`/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`);
+      for (const entry of tree.tree) {
+        if (entry.type === "blob") {
+          treeMap.set(entry.path, entry.sha);
+        }
+      }
+    } catch (e) {
+      console.error(
+        JSON.stringify({
+          error: `Failed to fetch file tree from ${ownerRepo}@${ref}: ${e.message.slice(0, 200)}`,
+        })
+      );
+      process.exit(1);
+    }
+  }
+
+  // Find or create the package entry in registry
+  let pkgEntry = findInstalledPackage(local, ownerRepo);
+  if (!pkgEntry) {
+    pkgEntry = { source: ownerRepo, ref, installed: { extensions: {}, skills: {} } };
+    local.packages.push(pkgEntry);
+  } else {
+    // Update ref if it changed
+    pkgEntry.ref = ref;
+  }
+
+  for (const type of ["extensions", "skills"]) {
+    for (const [name, info] of Object.entries(toInstallByType[type])) {
+      if (conflictNames.has(name)) continue;
+
+      const isUpdate = name in (pkgEntry.installed[type] || {});
+      const itemPath = info.path;
+
+      try {
+        const prefix = itemPath.endsWith("/") ? itemPath : itemPath + "/";
+        const files = [];
+        for (const [filePath, sha] of treeMap) {
+          if (filePath.startsWith(prefix) || filePath === itemPath) {
+            files.push({ path: filePath, sha });
+          }
+        }
+
+        if (files.length === 0) {
+          result.errors.push({ name, error: `No files found in tree under ${itemPath}` });
+          continue;
+        }
+
+        let fileCount = 0;
+        for (const file of files) {
+          const content = ghBlob(owner, repo, file.sha);
+          const localPath = path.join(root, file.path);
+          fs.mkdirSync(path.dirname(localPath), { recursive: true });
+          fs.writeFileSync(localPath, content);
+          fileCount++;
+        }
+
+        let npmInstalled = false;
+        const pkgJsonPath = path.join(root, itemPath, "package.json");
+        if (fs.existsSync(pkgJsonPath)) {
+          try {
+            execSync("npm install --production", {
+              cwd: path.join(root, itemPath),
+              encoding: "utf8",
+              stdio: "pipe",
+              timeout: 120000,
+            });
+            npmInstalled = true;
+          } catch (e) {
+            result.errors.push({
+              name,
+              error: `npm install failed: ${e.message.slice(0, 200)}`,
+            });
+          }
+        }
+
+        const itemMeta = { version: info.version, path: info.path, description: info.description };
+
+        // Update package entry
+        if (!pkgEntry.installed[type]) pkgEntry.installed[type] = {};
+        pkgEntry.installed[type][name] = itemMeta;
+
+        const entry = {
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          files: fileCount,
+          npmInstalled,
+        };
+
+        if (isUpdate) {
+          result.updated.push(entry);
+        } else {
+          result.installed.push(entry);
+        }
+      } catch (e) {
+        result.errors.push({ name, error: e.message.slice(0, 300) });
+      }
+    }
+  }
+
+  if (result.installed.length > 0 || result.updated.length > 0) {
+    // Merge into top-level registry
+    mergeIntoTopLevel(local, ownerRepo, pkgEntry.installed);
+    writeLocalRegistry(root, local);
+    result.registryUpdated = true;
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Remove command ────────────────────────────────────────────────────────────
+
+function remove(rawSource, opts) {
+  const { owner, repo } = parsePackageSource(rawSource);
+  const ownerRepo = `${owner}/${repo}`;
+  const root = (opts && opts.root) || findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  const pkgEntry = findInstalledPackage(local, ownerRepo);
+
+  const result = {
+    source: ownerRepo,
+    removed: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  if (!pkgEntry) {
+    result.errors.push({ name: ownerRepo, error: "Package not found in local registry" });
+    return result;
+  }
+
+  // Determine which item names to remove
+  const requestedItems = (opts && opts.items)
+    ? new Set(opts.items)
+    : new Set([
+        ...Object.keys(pkgEntry.installed.extensions || {}),
+        ...Object.keys(pkgEntry.installed.skills || {}),
+      ]);
+
+  const pendingRemovals = [];
+
+  for (const type of ["extensions", "skills"]) {
+    for (const name of Array.from(requestedItems)) {
+      const items = pkgEntry.installed[type] || {};
+      if (!(name in items)) continue;
+
+      const info = items[name];
+      const itemDir = path.join(root, info.path);
+      let stagedDir = null;
+
+      try {
+        if (fs.existsSync(itemDir)) {
+          stagedDir = makeStagedRemovalPath(itemDir);
+          fs.renameSync(itemDir, stagedDir);
+        }
+
+        delete pkgEntry.installed[type][name];
+        pendingRemovals.push({ name, info, type, itemDir, stagedDir });
+      } catch (e) {
+        if (stagedDir && fs.existsSync(stagedDir)) {
+          fs.renameSync(stagedDir, itemDir);
+        }
+        result.errors.push({ name, error: e.message.slice(0, 300) });
+      }
+    }
+  }
+
+  if (pendingRemovals.length > 0) {
+    try {
+      // Remove from top-level registry
+      const removedNames = pendingRemovals.map((r) => r.name);
+      removeFromTopLevel(local, ownerRepo, removedNames);
+
+      // Remove the entire package entry if no items remain
+      const remainingExt = Object.keys(pkgEntry.installed.extensions || {}).length;
+      const remainingSkills = Object.keys(pkgEntry.installed.skills || {}).length;
+      if (remainingExt + remainingSkills === 0) {
+        local.packages = local.packages.filter((p) => p.source !== ownerRepo);
+      }
+
+      writeLocalRegistry(root, local);
+      result.registryUpdated = true;
+
+      for (const item of pendingRemovals) {
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.rmSync(item.stagedDir, { recursive: true, force: true });
+        }
+        result.removed.push({
+          name: item.name,
+          type: item.type === "extensions" ? "extension" : "skill",
+          version: item.info.version,
+          path: item.info.path,
+        });
+      }
+    } catch (e) {
+      // Rollback
+      for (let i = pendingRemovals.length - 1; i >= 0; i--) {
+        const item = pendingRemovals[i];
+        pkgEntry.installed[item.type][item.name] = item.info;
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.renameSync(item.stagedDir, item.itemDir);
+        }
+        result.errors.push({
+          name: item.name,
+          error: `Failed to update registry: ${e.message.slice(0, 300)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+// ── List command ──────────────────────────────────────────────────────────────
+
+function list(opts) {
+  const root = (opts && opts.root) || findRepoRoot();
+  const local = readLocalRegistry(root);
+  return buildListOutput(local);
+}
+
+// ── Check command ─────────────────────────────────────────────────────────────
+
+function check(rawSource, opts) {
+  const { owner, repo, ref: parsedRef } = parsePackageSource(rawSource);
+  const ref = (opts && opts.ref) || parsedRef || "main";
+  const ownerRepo = `${owner}/${repo}`;
+
+  const root = (opts && opts.root) || findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  const pkgEntry = findInstalledPackage(local, ownerRepo);
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${ref}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from ${ownerRepo}@${ref}: ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  const result = {
+    source: ownerRepo,
+    ref,
+    remoteVersion: remote.version,
+    updates: [],
+    new: [],
+    current: [],
+    notInstalled: !pkgEntry,
+  };
+
+  if (!pkgEntry) {
+    // Nothing installed yet — all remote items are "new"
+    for (const type of ["extensions", "skills"]) {
+      for (const [name, info] of Object.entries(remote[type] || {})) {
+        result.new.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          description: info.description,
+        });
+      }
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const installedItems = pkgEntry.installed[type] || {};
+
+    for (const [name, info] of Object.entries(installedItems)) {
+      const remoteItem = remoteItems[name];
+      if (!remoteItem) {
+        result.updates.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          localVersion: info.version,
+          status: "removed_upstream",
+        });
+      } else if (compareSemver(remoteItem.version, info.version) > 0) {
+        result.updates.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          localVersion: info.version,
+          remoteVersion: remoteItem.version,
+          status: "update_available",
+        });
+      } else {
+        result.current.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+        });
+      }
+    }
+
+    for (const [name, info] of Object.entries(remoteItems)) {
+      if (!(name in installedItems)) {
+        result.new.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          description: info.description,
+        });
+      }
+    }
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Exports (for testing) ────────────────────────────────────────────────────
+
+module.exports = {
+  parsePackageSource,
+  detectConflicts,
+  mergeIntoTopLevel,
+  removeFromTopLevel,
+  buildListOutput,
+  findInstalledPackage,
+  compareSemver,
+  remove,
+  list,
+};
+
+// ── CLI entry ─────────────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const [, , command, ...args] = process.argv;
+
+  function parseFlags(flagArgs) {
+    const flags = { items: null, ref: null };
+    for (let i = 0; i < flagArgs.length; i++) {
+      if (flagArgs[i] === "--ref" && flagArgs[i + 1]) {
+        flags.ref = flagArgs[++i];
+      } else if (flagArgs[i] === "--items" && flagArgs[i + 1]) {
+        flags.items = flagArgs[++i].split(",").map((s) => s.trim());
+      }
+    }
+    return flags;
+  }
+
+  switch (command) {
+    case "search": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js search <owner/repo[@ref]>" }));
+        process.exit(1);
+      }
+      search(args[0]);
+      break;
+    }
+    case "install": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js install <owner/repo[@ref]> [--ref <ref>] [--items name1,name2]" }));
+        process.exit(1);
+      }
+      const { ref, items } = parseFlags(args.slice(1));
+      install(args[0], { ref, items });
+      break;
+    }
+    case "remove": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js remove <owner/repo> [--items name1,name2]" }));
+        process.exit(1);
+      }
+      const { items } = parseFlags(args.slice(1));
+      console.log(JSON.stringify(remove(args[0], { items }), null, 2));
+      break;
+    }
+    case "list": {
+      console.log(JSON.stringify(list(), null, 2));
+      break;
+    }
+    case "check": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js check <owner/repo[@ref]> [--ref <ref>]" }));
+        process.exit(1);
+      }
+      const { ref } = parseFlags(args.slice(1));
+      check(args[0], { ref });
+      break;
+    }
+    default: {
+      console.error(JSON.stringify({
+        error: `Unknown command: ${command}. Use "search", "install", "remove", "list", or "check".`,
+      }));
+      process.exit(1);
+    }
+  }
+}

--- a/.github/skills/packages/packages.test.js
+++ b/.github/skills/packages/packages.test.js
@@ -1,0 +1,560 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const {
+  parsePackageSource,
+  detectConflicts,
+  mergeIntoTopLevel,
+  removeFromTopLevel,
+  buildListOutput,
+  findInstalledPackage,
+  compareSemver,
+  remove,
+  list,
+} = require("./packages.js");
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeTempRepo(registry, dirs = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "packages-test-"));
+  const ghDir = path.join(root, ".github");
+  fs.mkdirSync(ghDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(ghDir, "registry.json"),
+    JSON.stringify(registry, null, 2),
+    "utf8"
+  );
+  for (const dir of dirs) {
+    const full = path.join(root, dir);
+    fs.mkdirSync(full, { recursive: true });
+    fs.writeFileSync(path.join(full, "index.js"), "// stub", "utf8");
+  }
+  return root;
+}
+
+function readRegistry(root) {
+  return JSON.parse(
+    fs.readFileSync(path.join(root, ".github", "registry.json"), "utf8")
+  );
+}
+
+function makeBaseRegistry(overrides = {}) {
+  return {
+    version: "0.14.0",
+    source: "ianphil/genesis",
+    channel: "main",
+    extensions: {},
+    skills: {},
+    packages: [],
+    ...overrides,
+  };
+}
+
+// ── parsePackageSource ────────────────────────────────────────────────────────
+
+describe("parsePackageSource", () => {
+  it("parses owner/repo without ref", () => {
+    const result = parsePackageSource("someuser/cool-extensions");
+    assert.equal(result.owner, "someuser");
+    assert.equal(result.repo, "cool-extensions");
+    assert.equal(result.ref, null);
+  });
+
+  it("parses owner/repo@ref", () => {
+    const result = parsePackageSource("someuser/cool-extensions@v1.0.0");
+    assert.equal(result.owner, "someuser");
+    assert.equal(result.repo, "cool-extensions");
+    assert.equal(result.ref, "v1.0.0");
+  });
+
+  it("parses owner/repo@branch-name", () => {
+    const result = parsePackageSource("org/repo@feature/my-branch");
+    assert.equal(result.owner, "org");
+    assert.equal(result.repo, "repo");
+    assert.equal(result.ref, "feature/my-branch");
+  });
+
+  it("throws on missing slash", () => {
+    assert.throws(
+      () => parsePackageSource("nodash"),
+      /Invalid package source/
+    );
+  });
+
+  it("throws on leading slash", () => {
+    assert.throws(
+      () => parsePackageSource("/repo"),
+      /Invalid package source/
+    );
+  });
+
+  it("throws on trailing slash", () => {
+    assert.throws(
+      () => parsePackageSource("owner/"),
+      /Invalid package source/
+    );
+  });
+
+  it("handles org with hyphens and dots", () => {
+    const result = parsePackageSource("my-org/my.repo@v2.3.4");
+    assert.equal(result.owner, "my-org");
+    assert.equal(result.repo, "my.repo");
+    assert.equal(result.ref, "v2.3.4");
+  });
+});
+
+// ── compareSemver ─────────────────────────────────────────────────────────────
+
+describe("compareSemver", () => {
+  it("returns 0 for equal versions", () => {
+    assert.equal(compareSemver("1.0.0", "1.0.0"), 0);
+  });
+
+  it("returns 1 when a > b (major)", () => {
+    assert.equal(compareSemver("2.0.0", "1.9.9"), 1);
+  });
+
+  it("returns -1 when a < b (minor)", () => {
+    assert.equal(compareSemver("1.0.0", "1.1.0"), -1);
+  });
+
+  it("returns 1 when a > b (patch)", () => {
+    assert.equal(compareSemver("1.0.2", "1.0.1"), 1);
+  });
+
+  it("handles missing patch as 0", () => {
+    assert.equal(compareSemver("1.0", "1.0.0"), 0);
+  });
+});
+
+// ── findInstalledPackage ──────────────────────────────────────────────────────
+
+describe("findInstalledPackage", () => {
+  it("returns null when packages array is empty", () => {
+    const registry = makeBaseRegistry();
+    assert.equal(findInstalledPackage(registry, "someuser/pkg"), null);
+  });
+
+  it("returns null when package is not found", () => {
+    const registry = makeBaseRegistry({
+      packages: [{ source: "other/pkg", ref: null, installed: { extensions: {}, skills: {} } }],
+    });
+    assert.equal(findInstalledPackage(registry, "someuser/pkg"), null);
+  });
+
+  it("returns the matching package entry", () => {
+    const pkg = { source: "someuser/pkg", ref: "v1.0.0", installed: { extensions: {}, skills: {} } };
+    const registry = makeBaseRegistry({ packages: [pkg] });
+    assert.deepEqual(findInstalledPackage(registry, "someuser/pkg"), pkg);
+  });
+
+  it("matches by source only, ignoring ref", () => {
+    const pkg = { source: "someuser/pkg", ref: "v1.0.0", installed: { extensions: {}, skills: {} } };
+    const registry = makeBaseRegistry({ packages: [pkg] });
+    // Same source regardless of ref
+    assert.deepEqual(findInstalledPackage(registry, "someuser/pkg"), pkg);
+  });
+});
+
+// ── detectConflicts ───────────────────────────────────────────────────────────
+
+describe("detectConflicts", () => {
+  it("returns empty array when no conflicts", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.0", path: ".github/extensions/cron" } },
+    });
+    const incoming = { extensions: { weather: { version: "0.1.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 0);
+  });
+
+  it("detects conflict when template extension already exists", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.0", path: ".github/extensions/cron" } },
+    });
+    const incoming = { extensions: { cron: { version: "0.2.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 1);
+    assert.ok(conflicts[0].includes('"cron"'));
+    assert.ok(conflicts[0].includes("ianphil/genesis"));
+  });
+
+  it("detects conflict when another package already installed the same item", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "firstuser/pkg" },
+      },
+    });
+    const incoming = { extensions: { weather: { version: "0.2.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "seconduser/other-pkg");
+    assert.equal(conflicts.length, 1);
+    assert.ok(conflicts[0].includes("firstuser/pkg"));
+  });
+
+  it("no conflict when updating an item from the same package", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+      },
+    });
+    const incoming = { extensions: { weather: { version: "0.2.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 0);
+  });
+
+  it("detects conflicts in skills too", () => {
+    const registry = makeBaseRegistry({
+      skills: { "daily-report": { version: "0.1.0", path: ".github/skills/daily-report" } },
+    });
+    const incoming = {
+      extensions: {},
+      skills: { "daily-report": { version: "0.2.0" } },
+    };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 1);
+    assert.ok(conflicts[0].includes('"daily-report"'));
+  });
+
+  it("detects multiple conflicts across types", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.0", path: ".github/extensions/cron" } },
+      skills: { commit: { version: "0.1.0", path: ".github/skills/commit" } },
+    });
+    const incoming = {
+      extensions: { cron: { version: "0.2.0" } },
+      skills: { commit: { version: "0.2.0" } },
+    };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 2);
+  });
+});
+
+// ── mergeIntoTopLevel ─────────────────────────────────────────────────────────
+
+describe("mergeIntoTopLevel", () => {
+  it("adds extensions with package field", () => {
+    const registry = makeBaseRegistry();
+    const installed = {
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+      },
+      skills: {},
+    };
+    mergeIntoTopLevel(registry, "someuser/pkg", installed);
+    assert.ok("weather" in registry.extensions);
+    assert.equal(registry.extensions.weather.package, "someuser/pkg");
+    assert.equal(registry.extensions.weather.version, "0.1.0");
+  });
+
+  it("adds skills with package field", () => {
+    const registry = makeBaseRegistry();
+    const installed = {
+      extensions: {},
+      skills: {
+        "my-skill": { version: "0.2.0", path: ".github/skills/my-skill", description: "Skill" },
+      },
+    };
+    mergeIntoTopLevel(registry, "someuser/pkg", installed);
+    assert.ok("my-skill" in registry.skills);
+    assert.equal(registry.skills["my-skill"].package, "someuser/pkg");
+  });
+
+  it("does not touch existing template items", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.4", path: ".github/extensions/cron" } },
+    });
+    const installed = {
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+      },
+      skills: {},
+    };
+    mergeIntoTopLevel(registry, "someuser/pkg", installed);
+    assert.ok(!registry.extensions.cron.package);
+    assert.equal(registry.extensions.cron.version, "0.1.4");
+  });
+});
+
+// ── removeFromTopLevel ────────────────────────────────────────────────────────
+
+describe("removeFromTopLevel", () => {
+  it("removes extension owned by the package", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", package: "someuser/pkg" },
+        cron: { version: "0.1.4" },
+      },
+    });
+    removeFromTopLevel(registry, "someuser/pkg", ["weather"]);
+    assert.ok(!("weather" in registry.extensions));
+    assert.ok("cron" in registry.extensions);
+  });
+
+  it("does not remove items owned by other packages or template", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", package: "someuser/pkg" },
+        snow: { version: "0.1.0", package: "other/pkg" },
+        cron: { version: "0.1.4" },
+      },
+    });
+    removeFromTopLevel(registry, "someuser/pkg", ["weather", "snow", "cron"]);
+    assert.ok(!("weather" in registry.extensions));
+    assert.ok("snow" in registry.extensions);
+    assert.ok("cron" in registry.extensions);
+  });
+
+  it("removes skill owned by the package", () => {
+    const registry = makeBaseRegistry({
+      skills: {
+        "my-skill": { version: "0.1.0", package: "someuser/pkg" },
+      },
+    });
+    removeFromTopLevel(registry, "someuser/pkg", ["my-skill"]);
+    assert.ok(!("my-skill" in registry.skills));
+  });
+});
+
+// ── buildListOutput ───────────────────────────────────────────────────────────
+
+describe("buildListOutput", () => {
+  it("returns empty array when no packages", () => {
+    const registry = makeBaseRegistry();
+    assert.deepEqual(buildListOutput(registry), []);
+  });
+
+  it("returns empty array when packages key is missing", () => {
+    const registry = { version: "0.13.0", source: "ianphil/genesis", extensions: {}, skills: {} };
+    assert.deepEqual(buildListOutput(registry), []);
+  });
+
+  it("formats a package with extensions and skills", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: "v1.0.0",
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", description: "Weather lookups" },
+            },
+            skills: {
+              "weather-query": { version: "0.1.0", description: "Ask about weather" },
+            },
+          },
+        },
+      ],
+    });
+    const result = buildListOutput(registry);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].source, "someuser/pkg");
+    assert.equal(result[0].ref, "v1.0.0");
+    assert.equal(result[0].extensions.length, 1);
+    assert.equal(result[0].extensions[0].name, "weather");
+    assert.equal(result[0].skills.length, 1);
+    assert.equal(result[0].skills[0].name, "weather-query");
+  });
+
+  it("sets ref to null when not present", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        {
+          source: "someuser/pkg",
+          installed: { extensions: {}, skills: {} },
+        },
+      ],
+    });
+    const result = buildListOutput(registry);
+    assert.equal(result[0].ref, null);
+  });
+
+  it("lists multiple packages", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        { source: "user/pkg1", ref: null, installed: { extensions: {}, skills: {} } },
+        { source: "user/pkg2", ref: "v2.0.0", installed: { extensions: {}, skills: {} } },
+      ],
+    });
+    const result = buildListOutput(registry);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].source, "user/pkg1");
+    assert.equal(result[1].source, "user/pkg2");
+  });
+});
+
+// ── remove (filesystem) ───────────────────────────────────────────────────────
+
+describe("remove — filesystem", () => {
+  let root;
+
+  afterEach(() => {
+    if (root && fs.existsSync(root)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error when package is not installed", () => {
+    root = makeTempRepo(makeBaseRegistry());
+    const result = remove("someuser/pkg", { root });
+    assert.equal(result.errors.length, 1);
+    assert.ok(result.errors[0].error.includes("not found"));
+    assert.equal(result.removed.length, 0);
+    assert.equal(result.registryUpdated, false);
+  });
+
+  it("removes an installed extension and updates registry", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+      },
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: null,
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry, [".github/extensions/weather"]);
+
+    const result = remove("someuser/pkg", { root });
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "weather");
+    assert.equal(result.registryUpdated, true);
+
+    // Directory should be gone
+    assert.ok(!fs.existsSync(path.join(root, ".github/extensions/weather")));
+
+    // Registry should be cleaned up
+    const updated = readRegistry(root);
+    assert.ok(!("weather" in updated.extensions));
+    assert.equal(updated.packages.length, 0);
+  });
+
+  it("removes a specific item when --items is specified", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+        forecast: { version: "0.1.0", path: ".github/extensions/forecast", package: "someuser/pkg" },
+      },
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: null,
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+              forecast: { version: "0.1.0", path: ".github/extensions/forecast", description: "Forecast" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry, [
+      ".github/extensions/weather",
+      ".github/extensions/forecast",
+    ]);
+
+    const result = remove("someuser/pkg", { root, items: ["weather"] });
+
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "weather");
+
+    // forecast should still be there
+    assert.ok(fs.existsSync(path.join(root, ".github/extensions/forecast")));
+
+    // Package entry should remain (still has forecast)
+    const updated = readRegistry(root);
+    assert.equal(updated.packages.length, 1);
+    assert.ok("forecast" in updated.packages[0].installed.extensions);
+    assert.ok(!("weather" in updated.extensions));
+  });
+
+  it("removes package entry entirely when all items are removed", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+      },
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: null,
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry, [".github/extensions/weather"]);
+
+    remove("someuser/pkg", { root, items: ["weather"] });
+
+    const updated = readRegistry(root);
+    assert.equal(updated.packages.length, 0);
+  });
+});
+
+// ── list (filesystem) ─────────────────────────────────────────────────────────
+
+describe("list — filesystem", () => {
+  let root;
+
+  afterEach(() => {
+    if (root && fs.existsSync(root)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty array when no packages installed", () => {
+    root = makeTempRepo(makeBaseRegistry());
+    const result = list({ root });
+    assert.deepEqual(result, []);
+  });
+
+  it("returns list of installed packages", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: "v1.0.0",
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", description: "Weather" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry);
+    const result = list({ root });
+    assert.equal(result.length, 1);
+    assert.equal(result[0].source, "someuser/pkg");
+    assert.equal(result[0].extensions[0].name, "weather");
+  });
+
+  it("handles registry without packages key gracefully", () => {
+    const registry = {
+      version: "0.13.0",
+      source: "ianphil/genesis",
+      extensions: {},
+      skills: {},
+    };
+    root = makeTempRepo(registry);
+    const result = list({ root });
+    assert.deepEqual(result, []);
+  });
+});

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Genesis writes the soul, seeds memory, installs skills, then erases itself. The 
 |-----------|----------|
 | `SOUL.md` | Mind ...  personality, values, voice, mission |
 | `.working-memory/` | Memory ...  persists across sessions, decays when stale, consolidates when reinforced |
-| `.github/skills/` | Learned behaviors ...  commit, daily-report, upgrade |
+| `.github/skills/` | Learned behaviors ...  commit, daily-report, upgrade, packages |
 | `.github/extensions/` | Senses and limbs ...  how the mind touches the world |
 | `.github/registry.json` | Genome ...  tracks installed capabilities, enables evolution |
 | `domains/`, `initiatives/`, `expertise/` | Long-term knowledge ...  the mind's library |


### PR DESCRIPTION
## What
Promotes the **packages** skill (v0.1.0) from frontier to the stable main channel.

## What's included
- \.github/skills/packages/\ — SKILL.md, packages.js (671 lines), packages.test.js (40 tests)
- \egistry.json\ bump: 0.14.0 → 0.15.0, adds \packages: []\ array
- \README.md\ — updated skills list

## Why
Packages on main is the prerequisite for splitting frontier into its own repo. Every agent needs the ability to install from external repos.

## Integration tested
Full end-to-end against \ipdelete/genesis-test-package\: search, install, list, check, remove — including conflict detection (template cron vs package cron).