### PR TITLE
feat(upgrade): add --all flag and fix duplicate install entries

### DIFF
--- a/.github/registry.json
+++ b/.github/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.24.0",
+  "version": "0.25.0",
   "source": "ianphil/genesis",
   "channel": "main",
   "extensions": {
@@ -36,7 +36,7 @@
       "description": "Morning briefing — ADO, Teams, calendar, email, mind next-actions"
     },
     "upgrade": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "path": ".github/skills/upgrade",
       "description": "Pull new extensions and skills from the genesis template registry; migrate channel-based registries to package-based"
     },

--- a/.github/skills/upgrade/upgrade.js
+++ b/.github/skills/upgrade/upgrade.js
@@ -5,6 +5,7 @@
 // Usage:
 //   node upgrade.js check              — compare local vs remote registry
 //   node upgrade.js install name1,name2 — install/update selected items
+//   node upgrade.js install --all       — install/update everything from remote registry
 //   node upgrade.js remove name1,name2  — remove selected items from local
 //   node upgrade.js pin name1,name2     — pin items to prevent removal
 //   node upgrade.js channel <name>      — switch release channel (e.g. main, frontier)
@@ -403,15 +404,6 @@ function install(names) {
           }
           entry.renamedFrom = oldName;
         }
-
-        if (isNew) {
-          result.installed.push(entry);
-        } else {
-          result.updated.push({
-            ...entry,
-            from: localItems[name].version,
-          });
-        }
       } catch (e) {
         result.errors.push({
           name,
@@ -748,15 +740,36 @@ if (require.main === module) {
       check();
       break;
     case "install":
-      if (!args[0]) {
+      if (args[0] === "--all") {
+        const allRoot = findRepoRoot();
+        const allLocal = readLocalRegistry(allRoot);
+        const allParsed = parseSource(allLocal.source);
+        const allBranch = resolveChannel(allLocal);
+        const allRemoteRaw = gh(
+          `/repos/${allParsed.owner}/${allParsed.repo}/contents/.github/registry.json?ref=${allBranch}`
+        );
+        const allRemote = JSON.parse(
+          Buffer.from(allRemoteRaw.content, "base64").toString("utf8")
+        );
+        const allNames = [
+          ...Object.keys(allRemote.extensions || {}),
+          ...Object.keys(allRemote.skills || {}),
+        ];
+        if (allNames.length === 0) {
+          console.log(JSON.stringify({ installed: [], updated: [], errors: [], note: "No items in remote registry" }));
+          break;
+        }
+        install(allNames);
+      } else if (!args[0]) {
         console.error(
           JSON.stringify({
-            error: "Usage: node upgrade.js install name1,name2,...",
+            error: "Usage: node upgrade.js install name1,name2,... | --all",
           })
         );
         process.exit(1);
+      } else {
+        install(args[0].split(",").map((s) => s.trim()));
       }
-      install(args[0].split(",").map((s) => s.trim()));
       break;
     case "remove":
       if (!args[0]) {


### PR DESCRIPTION
## Changes

### install --all flag
Resolves all extension and skill names from the remote registry and installs them in one operation. Used by Chamber genesis bootstrap (v0.14.0) to pull all capabilities for new minds.

### Duplicate push fix
install() was pushing items to installed/updated arrays twice - once in the main block and again after the rename handler. Removed the second push. Every item now appears exactly once in the output.

## Testing
- 48 existing tests pass
- Tested full bootstrap chain: seed empty registry, pull upgrade skill, run install --all, all 8 items installed, 0 errors, no duplicates