### PR TITLE
fix(idea): isolate per-agent index to prevent cross-agent DB collisions

### DIFF
--- a/.github/extensions/idea/lib/qmd.mjs
+++ b/.github/extensions/idea/lib/qmd.mjs
@@ -1,13 +1,56 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 
+const IDEA_FOLDERS = ["domains", "initiatives", "expertise", "inbox"];
+
 let qmdModulePromise;
 
-export function getDefaultDbPath() {
+export function getRepoRoot() {
+  // Extension lives at .github/extensions/idea/lib/qmd.mjs — 4 levels up.
+  const thisFile = fileURLToPath(import.meta.url);
+  const root = resolve(dirname(thisFile), "..", "..", "..", "..");
+
+  // Validate: the expected extension path should exist under root.
+  const probe = join(root, ".github", "extensions", "idea");
+  if (!existsSync(probe)) {
+    throw new Error(
+      `IDEA: derived repo root "${root}" looks wrong — expected ${probe} to exist.`,
+    );
+  }
+
+  return root;
+}
+
+export function getAgentDbPath(repoRoot) {
   const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  return join(home, ".cache", "qmd", "index.sqlite");
+  const name = basename(repoRoot);
+  const hash = createHash("sha256").update(resolve(repoRoot)).digest("hex").slice(0, 8);
+  const dir = join(home, ".cache", "qmd", `${name}-${hash}`);
+  mkdirSync(dir, { recursive: true });
+  return join(dir, "index.sqlite");
+}
+
+export function discoverCollections(repoRoot) {
+  const collections = {};
+  for (const folder of IDEA_FOLDERS) {
+    const folderPath = join(repoRoot, folder);
+    if (existsSync(folderPath)) {
+      collections[folder] = { path: folderPath, pattern: "**/*.md" };
+    }
+  }
+
+  if (Object.keys(collections).length === 0) {
+    throw new Error(
+      `IDEA: no collections found under "${repoRoot}". ` +
+      `Expected at least one of: ${IDEA_FOLDERS.join(", ")}`,
+    );
+  }
+
+  return { collections };
 }
 
 export async function loadQmd() {
@@ -50,7 +93,10 @@ export async function loadQmd() {
 
 export async function openStore() {
   const { createStore } = await loadQmd();
-  return createStore({ dbPath: getDefaultDbPath() });
+  const repoRoot = getRepoRoot();
+  const dbPath = getAgentDbPath(repoRoot);
+  const config = discoverCollections(repoRoot);
+  return createStore({ dbPath, config });
 }
 
 export const { extractSnippet, addLineNumbers } = await loadQmd();


### PR DESCRIPTION
## Problem

All agents on the same machine share a single QMD SQLite database at \~/.cache/qmd/index.sqlite\. When multiple agents run, \syncConfigToDb()\ is destructive — whichever agent syncs last wins and wipes the others' collections. Result: agents index the wrong mind.

## Fix

Each agent now gets its own isolated index:

- **Per-agent DB path**: \~/.cache/qmd/{name}-{shortHash}/index.sqlite\ — readable basename + hash of the full repo path to prevent collisions
- **Auto-discover collections**: scans for standard IDEA folders (\domains/\, \initiatives/\, \xpertise/\, \inbox/\) at the repo root, only includes those that exist on disk
- **Fail-safe**: throws if zero collections found (prevents accidental DB wipe from bad root detection)
- **Inline config**: passes discovered collections to \createStore({ dbPath, config })\ instead of relying on a shared YAML

## Changes

One file: \.github/extensions/idea/lib/qmd.mjs\

No changes needed to \xtension.mjs\ or \mbed.mjs\ — they just call \openStore()\.

## Testing

Verified on a machine running 5 agents:
- \idea_status\ shows correct collections with correct paths
- \idea_reindex\ indexed 210 documents across 4 collections
- \idea_search\ returns correct results
- New per-agent DB directory created at \~/.cache/qmd/miss-moneypenny-fe6dee86/\
- Old shared DB untouched (no data loss for other agents)